### PR TITLE
Improve dashboard card UX: enhanced duration input and Areas/Labels tabs

### DIFF
--- a/custom_components/autosnooze/manifest.json
+++ b/custom_components/autosnooze/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "service",
   "iot_class": "local_push",
   "requirements": [],
-  "version": "2.7.0"
+  "version": "2.8.0"
 }

--- a/custom_components/autosnooze/www/autosnooze-card.js
+++ b/custom_components/autosnooze/www/autosnooze-card.js
@@ -1,4 +1,4 @@
-const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,s=Symbol(),i=new WeakMap;let o=class{constructor(t,e,i){if(this._$cssResult$=!0,i!==s)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=t,this.t=e}get styleSheet(){let t=this.o;const s=this.t;if(e&&void 0===t){const e=void 0!==s&&1===s.length;e&&(t=i.get(s)),void 0===t&&((this.o=t=new CSSStyleSheet).replaceSync(this.cssText),e&&i.set(s,t))}return t}toString(){return this.cssText}};const r=(t,...e)=>{const i=1===t.length?t[0]:e.reduce((e,s,i)=>e+(t=>{if(!0===t._$cssResult$)return t.cssText;if("number"==typeof t)return t;throw Error("Value passed to 'css' function must be a 'css' function result: "+t+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(s)+t[i+1],t[0]);return new o(i,t,s)},a=e?t=>t:t=>t instanceof CSSStyleSheet?(t=>{let e="";for(const s of t.cssRules)e+=s.cssText;return(t=>new o("string"==typeof t?t:t+"",void 0,s))(e)})(t):t;var n;const l=window,d=l.trustedTypes,c=d?d.emptyScript:"",h=l.reactiveElementPolyfillSupport,u={toAttribute(t,e){switch(e){case Boolean:t=t?c:null;break;case Object:case Array:t=null==t?t:JSON.stringify(t)}return t},fromAttribute(t,e){let s=t;switch(e){case Boolean:s=null!==t;break;case Number:s=null===t?null:Number(t);break;case Object:case Array:try{s=JSON.parse(t)}catch(t){s=null}}return s}},p=(t,e)=>e!==t&&(e==e||t==t),m={attribute:!0,type:String,converter:u,reflect:!1,hasChanged:p},_="finalized";let g=class extends HTMLElement{constructor(){super(),this._$Ei=new Map,this.isUpdatePending=!1,this.hasUpdated=!1,this._$El=null,this._$Eu()}static addInitializer(t){var e;this.finalize(),(null!==(e=this.h)&&void 0!==e?e:this.h=[]).push(t)}static get observedAttributes(){this.finalize();const t=[];return this.elementProperties.forEach((e,s)=>{const i=this._$Ep(s,e);void 0!==i&&(this._$Ev.set(i,s),t.push(i))}),t}static createProperty(t,e=m){if(e.state&&(e.attribute=!1),this.finalize(),this.elementProperties.set(t,e),!e.noAccessor&&!this.prototype.hasOwnProperty(t)){const s="symbol"==typeof t?Symbol():"__"+t,i=this.getPropertyDescriptor(t,s,e);void 0!==i&&Object.defineProperty(this.prototype,t,i)}}static getPropertyDescriptor(t,e,s){return{get(){return this[e]},set(i){const o=this[t];this[e]=i,this.requestUpdate(t,o,s)},configurable:!0,enumerable:!0}}static getPropertyOptions(t){return this.elementProperties.get(t)||m}static finalize(){if(this.hasOwnProperty(_))return!1;this[_]=!0;const t=Object.getPrototypeOf(this);if(t.finalize(),void 0!==t.h&&(this.h=[...t.h]),this.elementProperties=new Map(t.elementProperties),this._$Ev=new Map,this.hasOwnProperty("properties")){const t=this.properties,e=[...Object.getOwnPropertyNames(t),...Object.getOwnPropertySymbols(t)];for(const s of e)this.createProperty(s,t[s])}return this.elementStyles=this.finalizeStyles(this.styles),!0}static finalizeStyles(t){const e=[];if(Array.isArray(t)){const s=new Set(t.flat(1/0).reverse());for(const t of s)e.unshift(a(t))}else void 0!==t&&e.push(a(t));return e}static _$Ep(t,e){const s=e.attribute;return!1===s?void 0:"string"==typeof s?s:"string"==typeof t?t.toLowerCase():void 0}_$Eu(){var t;this._$E_=new Promise(t=>this.enableUpdating=t),this._$AL=new Map,this._$Eg(),this.requestUpdate(),null===(t=this.constructor.h)||void 0===t||t.forEach(t=>t(this))}addController(t){var e,s;(null!==(e=this._$ES)&&void 0!==e?e:this._$ES=[]).push(t),void 0!==this.renderRoot&&this.isConnected&&(null===(s=t.hostConnected)||void 0===s||s.call(t))}removeController(t){var e;null===(e=this._$ES)||void 0===e||e.splice(this._$ES.indexOf(t)>>>0,1)}_$Eg(){this.constructor.elementProperties.forEach((t,e)=>{this.hasOwnProperty(e)&&(this._$Ei.set(e,this[e]),delete this[e])})}createRenderRoot(){var s;const i=null!==(s=this.shadowRoot)&&void 0!==s?s:this.attachShadow(this.constructor.shadowRootOptions);return((s,i)=>{e?s.adoptedStyleSheets=i.map(t=>t instanceof CSSStyleSheet?t:t.styleSheet):i.forEach(e=>{const i=document.createElement("style"),o=t.litNonce;void 0!==o&&i.setAttribute("nonce",o),i.textContent=e.cssText,s.appendChild(i)})})(i,this.constructor.elementStyles),i}connectedCallback(){var t;void 0===this.renderRoot&&(this.renderRoot=this.createRenderRoot()),this.enableUpdating(!0),null===(t=this._$ES)||void 0===t||t.forEach(t=>{var e;return null===(e=t.hostConnected)||void 0===e?void 0:e.call(t)})}enableUpdating(t){}disconnectedCallback(){var t;null===(t=this._$ES)||void 0===t||t.forEach(t=>{var e;return null===(e=t.hostDisconnected)||void 0===e?void 0:e.call(t)})}attributeChangedCallback(t,e,s){this._$AK(t,s)}_$EO(t,e,s=m){var i;const o=this.constructor._$Ep(t,s);if(void 0!==o&&!0===s.reflect){const r=(void 0!==(null===(i=s.converter)||void 0===i?void 0:i.toAttribute)?s.converter:u).toAttribute(e,s.type);this._$El=t,null==r?this.removeAttribute(o):this.setAttribute(o,r),this._$El=null}}_$AK(t,e){var s;const i=this.constructor,o=i._$Ev.get(t);if(void 0!==o&&this._$El!==o){const t=i.getPropertyOptions(o),r="function"==typeof t.converter?{fromAttribute:t.converter}:void 0!==(null===(s=t.converter)||void 0===s?void 0:s.fromAttribute)?t.converter:u;this._$El=o,this[o]=r.fromAttribute(e,t.type),this._$El=null}}requestUpdate(t,e,s){let i=!0;void 0!==t&&(((s=s||this.constructor.getPropertyOptions(t)).hasChanged||p)(this[t],e)?(this._$AL.has(t)||this._$AL.set(t,e),!0===s.reflect&&this._$El!==t&&(void 0===this._$EC&&(this._$EC=new Map),this._$EC.set(t,s))):i=!1),!this.isUpdatePending&&i&&(this._$E_=this._$Ej())}async _$Ej(){this.isUpdatePending=!0;try{await this._$E_}catch(t){Promise.reject(t)}const t=this.scheduleUpdate();return null!=t&&await t,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){var t;if(!this.isUpdatePending)return;this.hasUpdated,this._$Ei&&(this._$Ei.forEach((t,e)=>this[e]=t),this._$Ei=void 0);let e=!1;const s=this._$AL;try{e=this.shouldUpdate(s),e?(this.willUpdate(s),null===(t=this._$ES)||void 0===t||t.forEach(t=>{var e;return null===(e=t.hostUpdate)||void 0===e?void 0:e.call(t)}),this.update(s)):this._$Ek()}catch(t){throw e=!1,this._$Ek(),t}e&&this._$AE(s)}willUpdate(t){}_$AE(t){var e;null===(e=this._$ES)||void 0===e||e.forEach(t=>{var e;return null===(e=t.hostUpdated)||void 0===e?void 0:e.call(t)}),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(t)),this.updated(t)}_$Ek(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$E_}shouldUpdate(t){return!0}update(t){void 0!==this._$EC&&(this._$EC.forEach((t,e)=>this._$EO(e,this[e],t)),this._$EC=void 0),this._$Ek()}updated(t){}firstUpdated(t){}};var v;g[_]=!0,g.elementProperties=new Map,g.elementStyles=[],g.shadowRootOptions={mode:"open"},null==h||h({ReactiveElement:g}),(null!==(n=l.reactiveElementVersions)&&void 0!==n?n:l.reactiveElementVersions=[]).push("1.6.3");const b=window,f=b.trustedTypes,$=f?f.createPolicy("lit-html",{createHTML:t=>t}):void 0,y="$lit$",x=`lit$${(Math.random()+"").slice(9)}$`,A="?"+x,S=`<${A}>`,w=document,k=()=>w.createComment(""),E=t=>null===t||"object"!=typeof t&&"function"!=typeof t,z=Array.isArray,C="[ \t\n\f\r]",T=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,D=/-->/g,U=/>/g,P=RegExp(`>|${C}(?:([^\\s"'>=/]+)(${C}*=${C}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),M=/'/g,O=/"/g,N=/^(?:script|style|textarea|title)$/i,H=(t=>(e,...s)=>({_$litType$:t,strings:e,values:s}))(1),R=Symbol.for("lit-noChange"),L=Symbol.for("lit-nothing"),j=new WeakMap,I=w.createTreeWalker(w,129,null,!1);function B(t,e){if(!Array.isArray(t)||!t.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==$?$.createHTML(e):e}const F=(t,e)=>{const s=t.length-1,i=[];let o,r=2===e?"<svg>":"",a=T;for(let e=0;e<s;e++){const s=t[e];let n,l,d=-1,c=0;for(;c<s.length&&(a.lastIndex=c,l=a.exec(s),null!==l);)c=a.lastIndex,a===T?"!--"===l[1]?a=D:void 0!==l[1]?a=U:void 0!==l[2]?(N.test(l[2])&&(o=RegExp("</"+l[2],"g")),a=P):void 0!==l[3]&&(a=P):a===P?">"===l[0]?(a=null!=o?o:T,d=-1):void 0===l[1]?d=-2:(d=a.lastIndex-l[2].length,n=l[1],a=void 0===l[3]?P:'"'===l[3]?O:M):a===O||a===M?a=P:a===D||a===U?a=T:(a=P,o=void 0);const h=a===P&&t[e+1].startsWith("/>")?" ":"";r+=a===T?s+S:d>=0?(i.push(n),s.slice(0,d)+y+s.slice(d)+x+h):s+x+(-2===d?(i.push(void 0),e):h)}return[B(t,r+(t[s]||"<?>")+(2===e?"</svg>":"")),i]};class G{constructor({strings:t,_$litType$:e},s){let i;this.parts=[];let o=0,r=0;const a=t.length-1,n=this.parts,[l,d]=F(t,e);if(this.el=G.createElement(l,s),I.currentNode=this.el.content,2===e){const t=this.el.content,e=t.firstChild;e.remove(),t.append(...e.childNodes)}for(;null!==(i=I.nextNode())&&n.length<a;){if(1===i.nodeType){if(i.hasAttributes()){const t=[];for(const e of i.getAttributeNames())if(e.endsWith(y)||e.startsWith(x)){const s=d[r++];if(t.push(e),void 0!==s){const t=i.getAttribute(s.toLowerCase()+y).split(x),e=/([.?@])?(.*)/.exec(s);n.push({type:1,index:o,name:e[2],strings:t,ctor:"."===e[1]?J:"?"===e[1]?Y:"@"===e[1]?Z:X})}else n.push({type:6,index:o})}for(const e of t)i.removeAttribute(e)}if(N.test(i.tagName)){const t=i.textContent.split(x),e=t.length-1;if(e>0){i.textContent=f?f.emptyScript:"";for(let s=0;s<e;s++)i.append(t[s],k()),I.nextNode(),n.push({type:2,index:++o});i.append(t[e],k())}}}else if(8===i.nodeType)if(i.data===A)n.push({type:2,index:o});else{let t=-1;for(;-1!==(t=i.data.indexOf(x,t+1));)n.push({type:7,index:o}),t+=x.length-1}o++}}static createElement(t,e){const s=w.createElement("template");return s.innerHTML=t,s}}function W(t,e,s=t,i){var o,r,a,n;if(e===R)return e;let l=void 0!==i?null===(o=s._$Co)||void 0===o?void 0:o[i]:s._$Cl;const d=E(e)?void 0:e._$litDirective$;return(null==l?void 0:l.constructor)!==d&&(null===(r=null==l?void 0:l._$AO)||void 0===r||r.call(l,!1),void 0===d?l=void 0:(l=new d(t),l._$AT(t,s,i)),void 0!==i?(null!==(a=(n=s)._$Co)&&void 0!==a?a:n._$Co=[])[i]=l:s._$Cl=l),void 0!==l&&(e=W(t,l._$AS(t,e.values),l,i)),e}class V{constructor(t,e){this._$AV=[],this._$AN=void 0,this._$AD=t,this._$AM=e}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(t){var e;const{el:{content:s},parts:i}=this._$AD,o=(null!==(e=null==t?void 0:t.creationScope)&&void 0!==e?e:w).importNode(s,!0);I.currentNode=o;let r=I.nextNode(),a=0,n=0,l=i[0];for(;void 0!==l;){if(a===l.index){let e;2===l.type?e=new q(r,r.nextSibling,this,t):1===l.type?e=new l.ctor(r,l.name,l.strings,this,t):6===l.type&&(e=new Q(r,this,t)),this._$AV.push(e),l=i[++n]}a!==(null==l?void 0:l.index)&&(r=I.nextNode(),a++)}return I.currentNode=w,o}v(t){let e=0;for(const s of this._$AV)void 0!==s&&(void 0!==s.strings?(s._$AI(t,s,e),e+=s.strings.length-2):s._$AI(t[e])),e++}}class q{constructor(t,e,s,i){var o;this.type=2,this._$AH=L,this._$AN=void 0,this._$AA=t,this._$AB=e,this._$AM=s,this.options=i,this._$Cp=null===(o=null==i?void 0:i.isConnected)||void 0===o||o}get _$AU(){var t,e;return null!==(e=null===(t=this._$AM)||void 0===t?void 0:t._$AU)&&void 0!==e?e:this._$Cp}get parentNode(){let t=this._$AA.parentNode;const e=this._$AM;return void 0!==e&&11===(null==t?void 0:t.nodeType)&&(t=e.parentNode),t}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(t,e=this){t=W(this,t,e),E(t)?t===L||null==t||""===t?(this._$AH!==L&&this._$AR(),this._$AH=L):t!==this._$AH&&t!==R&&this._(t):void 0!==t._$litType$?this.g(t):void 0!==t.nodeType?this.$(t):(t=>z(t)||"function"==typeof(null==t?void 0:t[Symbol.iterator]))(t)?this.T(t):this._(t)}k(t){return this._$AA.parentNode.insertBefore(t,this._$AB)}$(t){this._$AH!==t&&(this._$AR(),this._$AH=this.k(t))}_(t){this._$AH!==L&&E(this._$AH)?this._$AA.nextSibling.data=t:this.$(w.createTextNode(t)),this._$AH=t}g(t){var e;const{values:s,_$litType$:i}=t,o="number"==typeof i?this._$AC(t):(void 0===i.el&&(i.el=G.createElement(B(i.h,i.h[0]),this.options)),i);if((null===(e=this._$AH)||void 0===e?void 0:e._$AD)===o)this._$AH.v(s);else{const t=new V(o,this),e=t.u(this.options);t.v(s),this.$(e),this._$AH=t}}_$AC(t){let e=j.get(t.strings);return void 0===e&&j.set(t.strings,e=new G(t)),e}T(t){z(this._$AH)||(this._$AH=[],this._$AR());const e=this._$AH;let s,i=0;for(const o of t)i===e.length?e.push(s=new q(this.k(k()),this.k(k()),this,this.options)):s=e[i],s._$AI(o),i++;i<e.length&&(this._$AR(s&&s._$AB.nextSibling,i),e.length=i)}_$AR(t=this._$AA.nextSibling,e){var s;for(null===(s=this._$AP)||void 0===s||s.call(this,!1,!0,e);t&&t!==this._$AB;){const e=t.nextSibling;t.remove(),t=e}}setConnected(t){var e;void 0===this._$AM&&(this._$Cp=t,null===(e=this._$AP)||void 0===e||e.call(this,t))}}class X{constructor(t,e,s,i,o){this.type=1,this._$AH=L,this._$AN=void 0,this.element=t,this.name=e,this._$AM=i,this.options=o,s.length>2||""!==s[0]||""!==s[1]?(this._$AH=Array(s.length-1).fill(new String),this.strings=s):this._$AH=L}get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}_$AI(t,e=this,s,i){const o=this.strings;let r=!1;if(void 0===o)t=W(this,t,e,0),r=!E(t)||t!==this._$AH&&t!==R,r&&(this._$AH=t);else{const i=t;let a,n;for(t=o[0],a=0;a<o.length-1;a++)n=W(this,i[s+a],e,a),n===R&&(n=this._$AH[a]),r||(r=!E(n)||n!==this._$AH[a]),n===L?t=L:t!==L&&(t+=(null!=n?n:"")+o[a+1]),this._$AH[a]=n}r&&!i&&this.j(t)}j(t){t===L?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,null!=t?t:"")}}class J extends X{constructor(){super(...arguments),this.type=3}j(t){this.element[this.name]=t===L?void 0:t}}const K=f?f.emptyScript:"";class Y extends X{constructor(){super(...arguments),this.type=4}j(t){t&&t!==L?this.element.setAttribute(this.name,K):this.element.removeAttribute(this.name)}}class Z extends X{constructor(t,e,s,i,o){super(t,e,s,i,o),this.type=5}_$AI(t,e=this){var s;if((t=null!==(s=W(this,t,e,0))&&void 0!==s?s:L)===R)return;const i=this._$AH,o=t===L&&i!==L||t.capture!==i.capture||t.once!==i.once||t.passive!==i.passive,r=t!==L&&(i===L||o);o&&this.element.removeEventListener(this.name,this,i),r&&this.element.addEventListener(this.name,this,t),this._$AH=t}handleEvent(t){var e,s;"function"==typeof this._$AH?this._$AH.call(null!==(s=null===(e=this.options)||void 0===e?void 0:e.host)&&void 0!==s?s:this.element,t):this._$AH.handleEvent(t)}}class Q{constructor(t,e,s){this.element=t,this.type=6,this._$AN=void 0,this._$AM=e,this.options=s}get _$AU(){return this._$AM._$AU}_$AI(t){W(this,t)}}const tt=b.litHtmlPolyfillSupport;null==tt||tt(G,q),(null!==(v=b.litHtmlVersions)&&void 0!==v?v:b.litHtmlVersions=[]).push("2.8.0");var et,st;class it extends g{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){var t,e;const s=super.createRenderRoot();return null!==(t=(e=this.renderOptions).renderBefore)&&void 0!==t||(e.renderBefore=s.firstChild),s}update(t){const e=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(t),this._$Do=((t,e,s)=>{var i,o;const r=null!==(i=null==s?void 0:s.renderBefore)&&void 0!==i?i:e;let a=r._$litPart$;if(void 0===a){const t=null!==(o=null==s?void 0:s.renderBefore)&&void 0!==o?o:null;r._$litPart$=a=new q(e.insertBefore(k(),t),t,void 0,null!=s?s:{})}return a._$AI(t),a})(e,this.renderRoot,this.renderOptions)}connectedCallback(){var t;super.connectedCallback(),null===(t=this._$Do)||void 0===t||t.setConnected(!0)}disconnectedCallback(){var t;super.disconnectedCallback(),null===(t=this._$Do)||void 0===t||t.setConnected(!1)}render(){return R}}it.finalized=!0,it._$litElement$=!0,null===(et=globalThis.litElementHydrateSupport)||void 0===et||et.call(globalThis,{LitElement:it});const ot=globalThis.litElementPolyfillSupport;null==ot||ot({LitElement:it}),(null!==(st=globalThis.litElementVersions)&&void 0!==st?st:globalThis.litElementVersions=[]).push("3.3.3");const rt="2.7.0";class at extends it{static properties={hass:{type:Object},_config:{state:!0}};static styles=r`
+const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,i=Symbol(),s=new WeakMap;let o=class{constructor(t,e,s){if(this._$cssResult$=!0,s!==i)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=t,this.t=e}get styleSheet(){let t=this.o;const i=this.t;if(e&&void 0===t){const e=void 0!==i&&1===i.length;e&&(t=s.get(i)),void 0===t&&((this.o=t=new CSSStyleSheet).replaceSync(this.cssText),e&&s.set(i,t))}return t}toString(){return this.cssText}};const r=(t,...e)=>{const s=1===t.length?t[0]:e.reduce((e,i,s)=>e+(t=>{if(!0===t._$cssResult$)return t.cssText;if("number"==typeof t)return t;throw Error("Value passed to 'css' function must be a 'css' function result: "+t+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(i)+t[s+1],t[0]);return new o(s,t,i)},a=e?t=>t:t=>t instanceof CSSStyleSheet?(t=>{let e="";for(const i of t.cssRules)e+=i.cssText;return(t=>new o("string"==typeof t?t:t+"",void 0,i))(e)})(t):t;var n;const l=window,d=l.trustedTypes,c=d?d.emptyScript:"",h=l.reactiveElementPolyfillSupport,u={toAttribute(t,e){switch(e){case Boolean:t=t?c:null;break;case Object:case Array:t=null==t?t:JSON.stringify(t)}return t},fromAttribute(t,e){let i=t;switch(e){case Boolean:i=null!==t;break;case Number:i=null===t?null:Number(t);break;case Object:case Array:try{i=JSON.parse(t)}catch(t){i=null}}return i}},p=(t,e)=>e!==t&&(e==e||t==t),m={attribute:!0,type:String,converter:u,reflect:!1,hasChanged:p},g="finalized";let _=class extends HTMLElement{constructor(){super(),this._$Ei=new Map,this.isUpdatePending=!1,this.hasUpdated=!1,this._$El=null,this._$Eu()}static addInitializer(t){var e;this.finalize(),(null!==(e=this.h)&&void 0!==e?e:this.h=[]).push(t)}static get observedAttributes(){this.finalize();const t=[];return this.elementProperties.forEach((e,i)=>{const s=this._$Ep(i,e);void 0!==s&&(this._$Ev.set(s,i),t.push(s))}),t}static createProperty(t,e=m){if(e.state&&(e.attribute=!1),this.finalize(),this.elementProperties.set(t,e),!e.noAccessor&&!this.prototype.hasOwnProperty(t)){const i="symbol"==typeof t?Symbol():"__"+t,s=this.getPropertyDescriptor(t,i,e);void 0!==s&&Object.defineProperty(this.prototype,t,s)}}static getPropertyDescriptor(t,e,i){return{get(){return this[e]},set(s){const o=this[t];this[e]=s,this.requestUpdate(t,o,i)},configurable:!0,enumerable:!0}}static getPropertyOptions(t){return this.elementProperties.get(t)||m}static finalize(){if(this.hasOwnProperty(g))return!1;this[g]=!0;const t=Object.getPrototypeOf(this);if(t.finalize(),void 0!==t.h&&(this.h=[...t.h]),this.elementProperties=new Map(t.elementProperties),this._$Ev=new Map,this.hasOwnProperty("properties")){const t=this.properties,e=[...Object.getOwnPropertyNames(t),...Object.getOwnPropertySymbols(t)];for(const i of e)this.createProperty(i,t[i])}return this.elementStyles=this.finalizeStyles(this.styles),!0}static finalizeStyles(t){const e=[];if(Array.isArray(t)){const i=new Set(t.flat(1/0).reverse());for(const t of i)e.unshift(a(t))}else void 0!==t&&e.push(a(t));return e}static _$Ep(t,e){const i=e.attribute;return!1===i?void 0:"string"==typeof i?i:"string"==typeof t?t.toLowerCase():void 0}_$Eu(){var t;this._$E_=new Promise(t=>this.enableUpdating=t),this._$AL=new Map,this._$Eg(),this.requestUpdate(),null===(t=this.constructor.h)||void 0===t||t.forEach(t=>t(this))}addController(t){var e,i;(null!==(e=this._$ES)&&void 0!==e?e:this._$ES=[]).push(t),void 0!==this.renderRoot&&this.isConnected&&(null===(i=t.hostConnected)||void 0===i||i.call(t))}removeController(t){var e;null===(e=this._$ES)||void 0===e||e.splice(this._$ES.indexOf(t)>>>0,1)}_$Eg(){this.constructor.elementProperties.forEach((t,e)=>{this.hasOwnProperty(e)&&(this._$Ei.set(e,this[e]),delete this[e])})}createRenderRoot(){var i;const s=null!==(i=this.shadowRoot)&&void 0!==i?i:this.attachShadow(this.constructor.shadowRootOptions);return((i,s)=>{e?i.adoptedStyleSheets=s.map(t=>t instanceof CSSStyleSheet?t:t.styleSheet):s.forEach(e=>{const s=document.createElement("style"),o=t.litNonce;void 0!==o&&s.setAttribute("nonce",o),s.textContent=e.cssText,i.appendChild(s)})})(s,this.constructor.elementStyles),s}connectedCallback(){var t;void 0===this.renderRoot&&(this.renderRoot=this.createRenderRoot()),this.enableUpdating(!0),null===(t=this._$ES)||void 0===t||t.forEach(t=>{var e;return null===(e=t.hostConnected)||void 0===e?void 0:e.call(t)})}enableUpdating(t){}disconnectedCallback(){var t;null===(t=this._$ES)||void 0===t||t.forEach(t=>{var e;return null===(e=t.hostDisconnected)||void 0===e?void 0:e.call(t)})}attributeChangedCallback(t,e,i){this._$AK(t,i)}_$EO(t,e,i=m){var s;const o=this.constructor._$Ep(t,i);if(void 0!==o&&!0===i.reflect){const r=(void 0!==(null===(s=i.converter)||void 0===s?void 0:s.toAttribute)?i.converter:u).toAttribute(e,i.type);this._$El=t,null==r?this.removeAttribute(o):this.setAttribute(o,r),this._$El=null}}_$AK(t,e){var i;const s=this.constructor,o=s._$Ev.get(t);if(void 0!==o&&this._$El!==o){const t=s.getPropertyOptions(o),r="function"==typeof t.converter?{fromAttribute:t.converter}:void 0!==(null===(i=t.converter)||void 0===i?void 0:i.fromAttribute)?t.converter:u;this._$El=o,this[o]=r.fromAttribute(e,t.type),this._$El=null}}requestUpdate(t,e,i){let s=!0;void 0!==t&&(((i=i||this.constructor.getPropertyOptions(t)).hasChanged||p)(this[t],e)?(this._$AL.has(t)||this._$AL.set(t,e),!0===i.reflect&&this._$El!==t&&(void 0===this._$EC&&(this._$EC=new Map),this._$EC.set(t,i))):s=!1),!this.isUpdatePending&&s&&(this._$E_=this._$Ej())}async _$Ej(){this.isUpdatePending=!0;try{await this._$E_}catch(t){Promise.reject(t)}const t=this.scheduleUpdate();return null!=t&&await t,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){var t;if(!this.isUpdatePending)return;this.hasUpdated,this._$Ei&&(this._$Ei.forEach((t,e)=>this[e]=t),this._$Ei=void 0);let e=!1;const i=this._$AL;try{e=this.shouldUpdate(i),e?(this.willUpdate(i),null===(t=this._$ES)||void 0===t||t.forEach(t=>{var e;return null===(e=t.hostUpdate)||void 0===e?void 0:e.call(t)}),this.update(i)):this._$Ek()}catch(t){throw e=!1,this._$Ek(),t}e&&this._$AE(i)}willUpdate(t){}_$AE(t){var e;null===(e=this._$ES)||void 0===e||e.forEach(t=>{var e;return null===(e=t.hostUpdated)||void 0===e?void 0:e.call(t)}),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(t)),this.updated(t)}_$Ek(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$E_}shouldUpdate(t){return!0}update(t){void 0!==this._$EC&&(this._$EC.forEach((t,e)=>this._$EO(e,this[e],t)),this._$EC=void 0),this._$Ek()}updated(t){}firstUpdated(t){}};var v;_[g]=!0,_.elementProperties=new Map,_.elementStyles=[],_.shadowRootOptions={mode:"open"},null==h||h({ReactiveElement:_}),(null!==(n=l.reactiveElementVersions)&&void 0!==n?n:l.reactiveElementVersions=[]).push("1.6.3");const b=window,f=b.trustedTypes,$=f?f.createPolicy("lit-html",{createHTML:t=>t}):void 0,y="$lit$",x=`lit$${(Math.random()+"").slice(9)}$`,A="?"+x,S=`<${A}>`,w=document,k=()=>w.createComment(""),z=t=>null===t||"object"!=typeof t&&"function"!=typeof t,E=Array.isArray,C="[ \t\n\f\r]",T=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,D=/-->/g,U=/>/g,P=RegExp(`>|${C}(?:([^\\s"'>=/]+)(${C}*=${C}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),M=/'/g,O=/"/g,N=/^(?:script|style|textarea|title)$/i,L=(t=>(e,...i)=>({_$litType$:t,strings:e,values:i}))(1),j=Symbol.for("lit-noChange"),H=Symbol.for("lit-nothing"),R=new WeakMap,I=w.createTreeWalker(w,129,null,!1);function B(t,e){if(!Array.isArray(t)||!t.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==$?$.createHTML(e):e}const F=(t,e)=>{const i=t.length-1,s=[];let o,r=2===e?"<svg>":"",a=T;for(let e=0;e<i;e++){const i=t[e];let n,l,d=-1,c=0;for(;c<i.length&&(a.lastIndex=c,l=a.exec(i),null!==l);)c=a.lastIndex,a===T?"!--"===l[1]?a=D:void 0!==l[1]?a=U:void 0!==l[2]?(N.test(l[2])&&(o=RegExp("</"+l[2],"g")),a=P):void 0!==l[3]&&(a=P):a===P?">"===l[0]?(a=null!=o?o:T,d=-1):void 0===l[1]?d=-2:(d=a.lastIndex-l[2].length,n=l[1],a=void 0===l[3]?P:'"'===l[3]?O:M):a===O||a===M?a=P:a===D||a===U?a=T:(a=P,o=void 0);const h=a===P&&t[e+1].startsWith("/>")?" ":"";r+=a===T?i+S:d>=0?(s.push(n),i.slice(0,d)+y+i.slice(d)+x+h):i+x+(-2===d?(s.push(void 0),e):h)}return[B(t,r+(t[i]||"<?>")+(2===e?"</svg>":"")),s]};class G{constructor({strings:t,_$litType$:e},i){let s;this.parts=[];let o=0,r=0;const a=t.length-1,n=this.parts,[l,d]=F(t,e);if(this.el=G.createElement(l,i),I.currentNode=this.el.content,2===e){const t=this.el.content,e=t.firstChild;e.remove(),t.append(...e.childNodes)}for(;null!==(s=I.nextNode())&&n.length<a;){if(1===s.nodeType){if(s.hasAttributes()){const t=[];for(const e of s.getAttributeNames())if(e.endsWith(y)||e.startsWith(x)){const i=d[r++];if(t.push(e),void 0!==i){const t=s.getAttribute(i.toLowerCase()+y).split(x),e=/([.?@])?(.*)/.exec(i);n.push({type:1,index:o,name:e[2],strings:t,ctor:"."===e[1]?J:"?"===e[1]?Y:"@"===e[1]?Z:X})}else n.push({type:6,index:o})}for(const e of t)s.removeAttribute(e)}if(N.test(s.tagName)){const t=s.textContent.split(x),e=t.length-1;if(e>0){s.textContent=f?f.emptyScript:"";for(let i=0;i<e;i++)s.append(t[i],k()),I.nextNode(),n.push({type:2,index:++o});s.append(t[e],k())}}}else if(8===s.nodeType)if(s.data===A)n.push({type:2,index:o});else{let t=-1;for(;-1!==(t=s.data.indexOf(x,t+1));)n.push({type:7,index:o}),t+=x.length-1}o++}}static createElement(t,e){const i=w.createElement("template");return i.innerHTML=t,i}}function V(t,e,i=t,s){var o,r,a,n;if(e===j)return e;let l=void 0!==s?null===(o=i._$Co)||void 0===o?void 0:o[s]:i._$Cl;const d=z(e)?void 0:e._$litDirective$;return(null==l?void 0:l.constructor)!==d&&(null===(r=null==l?void 0:l._$AO)||void 0===r||r.call(l,!1),void 0===d?l=void 0:(l=new d(t),l._$AT(t,i,s)),void 0!==s?(null!==(a=(n=i)._$Co)&&void 0!==a?a:n._$Co=[])[s]=l:i._$Cl=l),void 0!==l&&(e=V(t,l._$AS(t,e.values),l,s)),e}class W{constructor(t,e){this._$AV=[],this._$AN=void 0,this._$AD=t,this._$AM=e}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(t){var e;const{el:{content:i},parts:s}=this._$AD,o=(null!==(e=null==t?void 0:t.creationScope)&&void 0!==e?e:w).importNode(i,!0);I.currentNode=o;let r=I.nextNode(),a=0,n=0,l=s[0];for(;void 0!==l;){if(a===l.index){let e;2===l.type?e=new q(r,r.nextSibling,this,t):1===l.type?e=new l.ctor(r,l.name,l.strings,this,t):6===l.type&&(e=new Q(r,this,t)),this._$AV.push(e),l=s[++n]}a!==(null==l?void 0:l.index)&&(r=I.nextNode(),a++)}return I.currentNode=w,o}v(t){let e=0;for(const i of this._$AV)void 0!==i&&(void 0!==i.strings?(i._$AI(t,i,e),e+=i.strings.length-2):i._$AI(t[e])),e++}}class q{constructor(t,e,i,s){var o;this.type=2,this._$AH=H,this._$AN=void 0,this._$AA=t,this._$AB=e,this._$AM=i,this.options=s,this._$Cp=null===(o=null==s?void 0:s.isConnected)||void 0===o||o}get _$AU(){var t,e;return null!==(e=null===(t=this._$AM)||void 0===t?void 0:t._$AU)&&void 0!==e?e:this._$Cp}get parentNode(){let t=this._$AA.parentNode;const e=this._$AM;return void 0!==e&&11===(null==t?void 0:t.nodeType)&&(t=e.parentNode),t}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(t,e=this){t=V(this,t,e),z(t)?t===H||null==t||""===t?(this._$AH!==H&&this._$AR(),this._$AH=H):t!==this._$AH&&t!==j&&this._(t):void 0!==t._$litType$?this.g(t):void 0!==t.nodeType?this.$(t):(t=>E(t)||"function"==typeof(null==t?void 0:t[Symbol.iterator]))(t)?this.T(t):this._(t)}k(t){return this._$AA.parentNode.insertBefore(t,this._$AB)}$(t){this._$AH!==t&&(this._$AR(),this._$AH=this.k(t))}_(t){this._$AH!==H&&z(this._$AH)?this._$AA.nextSibling.data=t:this.$(w.createTextNode(t)),this._$AH=t}g(t){var e;const{values:i,_$litType$:s}=t,o="number"==typeof s?this._$AC(t):(void 0===s.el&&(s.el=G.createElement(B(s.h,s.h[0]),this.options)),s);if((null===(e=this._$AH)||void 0===e?void 0:e._$AD)===o)this._$AH.v(i);else{const t=new W(o,this),e=t.u(this.options);t.v(i),this.$(e),this._$AH=t}}_$AC(t){let e=R.get(t.strings);return void 0===e&&R.set(t.strings,e=new G(t)),e}T(t){E(this._$AH)||(this._$AH=[],this._$AR());const e=this._$AH;let i,s=0;for(const o of t)s===e.length?e.push(i=new q(this.k(k()),this.k(k()),this,this.options)):i=e[s],i._$AI(o),s++;s<e.length&&(this._$AR(i&&i._$AB.nextSibling,s),e.length=s)}_$AR(t=this._$AA.nextSibling,e){var i;for(null===(i=this._$AP)||void 0===i||i.call(this,!1,!0,e);t&&t!==this._$AB;){const e=t.nextSibling;t.remove(),t=e}}setConnected(t){var e;void 0===this._$AM&&(this._$Cp=t,null===(e=this._$AP)||void 0===e||e.call(this,t))}}class X{constructor(t,e,i,s,o){this.type=1,this._$AH=H,this._$AN=void 0,this.element=t,this.name=e,this._$AM=s,this.options=o,i.length>2||""!==i[0]||""!==i[1]?(this._$AH=Array(i.length-1).fill(new String),this.strings=i):this._$AH=H}get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}_$AI(t,e=this,i,s){const o=this.strings;let r=!1;if(void 0===o)t=V(this,t,e,0),r=!z(t)||t!==this._$AH&&t!==j,r&&(this._$AH=t);else{const s=t;let a,n;for(t=o[0],a=0;a<o.length-1;a++)n=V(this,s[i+a],e,a),n===j&&(n=this._$AH[a]),r||(r=!z(n)||n!==this._$AH[a]),n===H?t=H:t!==H&&(t+=(null!=n?n:"")+o[a+1]),this._$AH[a]=n}r&&!s&&this.j(t)}j(t){t===H?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,null!=t?t:"")}}class J extends X{constructor(){super(...arguments),this.type=3}j(t){this.element[this.name]=t===H?void 0:t}}const K=f?f.emptyScript:"";class Y extends X{constructor(){super(...arguments),this.type=4}j(t){t&&t!==H?this.element.setAttribute(this.name,K):this.element.removeAttribute(this.name)}}class Z extends X{constructor(t,e,i,s,o){super(t,e,i,s,o),this.type=5}_$AI(t,e=this){var i;if((t=null!==(i=V(this,t,e,0))&&void 0!==i?i:H)===j)return;const s=this._$AH,o=t===H&&s!==H||t.capture!==s.capture||t.once!==s.once||t.passive!==s.passive,r=t!==H&&(s===H||o);o&&this.element.removeEventListener(this.name,this,s),r&&this.element.addEventListener(this.name,this,t),this._$AH=t}handleEvent(t){var e,i;"function"==typeof this._$AH?this._$AH.call(null!==(i=null===(e=this.options)||void 0===e?void 0:e.host)&&void 0!==i?i:this.element,t):this._$AH.handleEvent(t)}}class Q{constructor(t,e,i){this.element=t,this.type=6,this._$AN=void 0,this._$AM=e,this.options=i}get _$AU(){return this._$AM._$AU}_$AI(t){V(this,t)}}const tt=b.litHtmlPolyfillSupport;null==tt||tt(G,q),(null!==(v=b.litHtmlVersions)&&void 0!==v?v:b.litHtmlVersions=[]).push("2.8.0");var et,it;class st extends _{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){var t,e;const i=super.createRenderRoot();return null!==(t=(e=this.renderOptions).renderBefore)&&void 0!==t||(e.renderBefore=i.firstChild),i}update(t){const e=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(t),this._$Do=((t,e,i)=>{var s,o;const r=null!==(s=null==i?void 0:i.renderBefore)&&void 0!==s?s:e;let a=r._$litPart$;if(void 0===a){const t=null!==(o=null==i?void 0:i.renderBefore)&&void 0!==o?o:null;r._$litPart$=a=new q(e.insertBefore(k(),t),t,void 0,null!=i?i:{})}return a._$AI(t),a})(e,this.renderRoot,this.renderOptions)}connectedCallback(){var t;super.connectedCallback(),null===(t=this._$Do)||void 0===t||t.setConnected(!0)}disconnectedCallback(){var t;super.disconnectedCallback(),null===(t=this._$Do)||void 0===t||t.setConnected(!1)}render(){return j}}st.finalized=!0,st._$litElement$=!0,null===(et=globalThis.litElementHydrateSupport)||void 0===et||et.call(globalThis,{LitElement:st});const ot=globalThis.litElementPolyfillSupport;null==ot||ot({LitElement:st}),(null!==(it=globalThis.litElementVersions)&&void 0!==it?it:globalThis.litElementVersions=[]).push("3.3.3");const rt="2.8.0";class at extends st{static properties={hass:{type:Object},_config:{state:!0}};static styles=r`
     .row {
       margin-bottom: 12px;
     }
@@ -21,7 +21,7 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
       color: var(--secondary-text-color);
       margin-top: 4px;
     }
-  `;constructor(){super(),this.hass={},this._config={}}setConfig(t){this._config=t}_valueChanged(t,e){if(!this._config)return;const s={...this._config,[t]:e};""!==e&&null!=e||delete s[t],this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:s},bubbles:!0,composed:!0}))}render(){return this._config?H`
+  `;constructor(){super(),this.hass={},this._config={}}setConfig(t){this._config=t}_valueChanged(t,e){if(!this._config)return;const i={...this._config,[t]:e};""!==e&&null!=e||delete i[t],this.dispatchEvent(new CustomEvent("config-changed",{detail:{config:i},bubbles:!0,composed:!0}))}render(){return this._config?L`
       <div class="row">
         <label>Title</label>
         <input
@@ -31,7 +31,7 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
           placeholder="AutoSnooze"
         />
       </div>
-    `:H``}}class nt extends it{static properties={hass:{type:Object},config:{type:Object},_selected:{state:!0},_duration:{state:!0},_customDuration:{state:!0},_customDurationInput:{state:!0},_loading:{state:!0},_search:{state:!0},_filterTab:{state:!0},_expandedGroups:{state:!0},_scheduleMode:{state:!0},_disableAt:{state:!0},_resumeAt:{state:!0},_labelRegistry:{state:!0}};constructor(){super(),this.hass={},this.config={},this._selected=[],this._duration=18e5,this._customDuration={days:0,hours:0,minutes:30},this._customDurationInput="30m",this._loading=!1,this._search="",this._filterTab="all",this._expandedGroups={},this._scheduleMode=!1,this._disableAt="",this._resumeAt="",this._labelRegistry={},this._interval=null,this._labelsFetched=!1,this._debugLogged=!1}connectedCallback(){super.connectedCallback(),this._interval=window.setInterval(()=>this.requestUpdate(),1e3),this._fetchLabelRegistry()}async _fetchLabelRegistry(){if(!this._labelsFetched&&this.hass?.connection)try{const t=await this.hass.connection.sendMessagePromise({type:"config/label_registry/list"}),e={};Array.isArray(t)&&t.forEach(t=>{e[t.label_id]=t}),this._labelRegistry=e,this._labelsFetched=!0,console.log("[AutoSnooze] Label registry fetched:",Object.keys(e).length,"labels")}catch(t){console.warn("[AutoSnooze] Failed to fetch label registry:",t)}}updated(t){super.updated(t),t.has("hass")&&!this._labelsFetched&&this.hass?.connection&&this._fetchLabelRegistry()}disconnectedCallback(){super.disconnectedCallback(),null!==this._interval&&(clearInterval(this._interval),this._interval=null)}static getConfigElement(){return document.createElement("autosnooze-card-editor")}static getStubConfig(){return{title:"AutoSnooze"}}static styles=r`
+    `:L``}}class nt extends st{static properties={hass:{type:Object},config:{type:Object},_selected:{state:!0},_duration:{state:!0},_customDuration:{state:!0},_customDurationInput:{state:!0},_loading:{state:!0},_search:{state:!0},_filterTab:{state:!0},_expandedGroups:{state:!0},_scheduleMode:{state:!0},_disableAt:{state:!0},_resumeAt:{state:!0},_labelRegistry:{state:!0}};constructor(){super(),this.hass={},this.config={},this._selected=[],this._duration=18e5,this._customDuration={days:0,hours:0,minutes:30},this._customDurationInput="30m",this._loading=!1,this._search="",this._filterTab="all",this._expandedGroups={},this._scheduleMode=!1,this._disableAt="",this._resumeAt="",this._labelRegistry={},this._interval=null,this._labelsFetched=!1,this._debugLogged=!1}connectedCallback(){super.connectedCallback(),this._interval=window.setInterval(()=>this.requestUpdate(),1e3),this._fetchLabelRegistry()}async _fetchLabelRegistry(){if(!this._labelsFetched&&this.hass?.connection)try{const t=await this.hass.connection.sendMessagePromise({type:"config/label_registry/list"}),e={};Array.isArray(t)&&t.forEach(t=>{e[t.label_id]=t}),this._labelRegistry=e,this._labelsFetched=!0,console.log("[AutoSnooze] Label registry fetched:",Object.keys(e).length,"labels")}catch(t){console.warn("[AutoSnooze] Failed to fetch label registry:",t)}}updated(t){super.updated(t),t.has("hass")&&!this._labelsFetched&&this.hass?.connection&&this._fetchLabelRegistry()}disconnectedCallback(){super.disconnectedCallback(),null!==this._interval&&(clearInterval(this._interval),this._interval=null)}static getConfigElement(){return document.createElement("autosnooze-card-editor")}static getStubConfig(){return{title:"AutoSnooze"}}static styles=r`
     :host {
       display: block;
     }
@@ -69,6 +69,7 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
       margin-bottom: 12px;
       border-bottom: 1px solid var(--divider-color);
       padding-bottom: 8px;
+      flex-wrap: wrap;
     }
     .tab {
       padding: 6px 16px;
@@ -79,6 +80,9 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
       border: 1px solid var(--divider-color);
       color: var(--primary-text-color);
       transition: all 0.2s;
+      display: flex;
+      align-items: center;
+      gap: 6px;
     }
     .tab:hover {
       background: var(--primary-color);
@@ -89,6 +93,15 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
       background: var(--primary-color);
       color: var(--text-primary-color);
       border-color: var(--primary-color);
+    }
+    .tab-count {
+      background: rgba(0, 0, 0, 0.2);
+      padding: 2px 6px;
+      border-radius: 10px;
+      font-size: 0.8em;
+    }
+    .tab.active .tab-count {
+      background: rgba(255, 255, 255, 0.2);
     }
 
     /* Search */
@@ -147,9 +160,28 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
       color: var(--primary-color);
       flex-shrink: 0;
     }
-    .list-item-name {
+    .list-item-content {
       flex: 1;
+      min-width: 0;
+    }
+    .list-item-name {
       font-size: 0.95em;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .list-item-meta {
+      font-size: 0.8em;
+      color: var(--secondary-text-color);
+      margin-top: 2px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .list-item-meta ha-icon {
+      --mdc-icon-size: 12px;
+      margin-right: 4px;
+      vertical-align: middle;
     }
 
     /* Group Headers */
@@ -180,6 +212,45 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
       color: var(--text-primary-color);
       border-radius: 12px;
       font-size: 0.8em;
+    }
+
+    /* Selection Actions */
+    .selection-actions {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 8px;
+      padding: 8px 12px;
+      background: var(--secondary-background-color);
+      border-radius: 8px;
+      align-items: center;
+      font-size: 0.9em;
+    }
+    .selection-actions span {
+      flex: 1;
+      color: var(--secondary-text-color);
+    }
+    .select-all-btn {
+      padding: 4px 12px;
+      border: 1px solid var(--divider-color);
+      border-radius: 6px;
+      background: var(--card-background-color);
+      color: var(--primary-text-color);
+      cursor: pointer;
+      font-size: 0.85em;
+      transition: all 0.2s;
+    }
+    .select-all-btn:hover {
+      background: var(--primary-color);
+      color: var(--text-primary-color);
+      border-color: var(--primary-color);
+    }
+
+    /* Duration Section */
+    .duration-section-header {
+      font-size: 0.9em;
+      font-weight: 500;
+      margin-bottom: 8px;
+      color: var(--secondary-text-color);
     }
 
     /* Duration Pills */
@@ -489,7 +560,7 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
         opacity: 1;
       }
     }
-  `;_getAutomations(){if(!this.hass?.states)return[];if(!this._debugLogged){if(this._debugLogged=!0,console.log("[AutoSnooze] Card version:",rt),console.log("[AutoSnooze] hass.entities available:",!!this.hass.entities,"count:",this.hass.entities?Object.keys(this.hass.entities).length:0),console.log("[AutoSnooze] hass.areas available:",!!this.hass.areas,"count:",this.hass.areas?Object.keys(this.hass.areas).length:0),console.log("[AutoSnooze] Label registry (fetched separately):",Object.keys(this._labelRegistry).length,"labels"),this.hass.entities){const t=Object.keys(this.hass.entities).find(t=>t.startsWith("automation."));t&&console.log("[AutoSnooze] Sample automation entity:",t,this.hass.entities[t])}this.hass.areas&&Object.keys(this.hass.areas).length>0&&console.log("[AutoSnooze] Areas:",Object.entries(this.hass.areas).map(([t,e])=>`${t}: ${e.name}`).join(", "))}return Object.keys(this.hass.states).filter(t=>t.startsWith("automation.")).map(t=>{const e=this.hass.states[t],s=this.hass.entities?.[t];return{id:t,name:e.attributes.friendly_name||t.replace("automation.",""),area_id:s?.area_id||null,labels:s?.labels||[]}}).sort((t,e)=>t.name.localeCompare(e.name))}_getFilteredAutomations(){const t=this._getAutomations(),e=this._search.toLowerCase();let s=t;return e&&(s=t.filter(t=>t.name.toLowerCase().includes(e)||t.id.toLowerCase().includes(e))),s}_getAreaName(t){if(!t)return"Unassigned";const e=this.hass.areas?.[t];return e?.name?e.name:t.replace(/_/g," ").replace(/\b\w/g,t=>t.toUpperCase())}_getLabelName(t){const e=this._labelRegistry[t];return e?.name?e.name:t.replace(/_/g," ").replace(/\b\w/g,t=>t.toUpperCase())}_getGroupedByArea(){const t=this._getFilteredAutomations(),e={};return t.forEach(t=>{const s=this._getAreaName(t.area_id);e[s]||(e[s]=[]),e[s].push(t)}),Object.entries(e).sort((t,e)=>"Unassigned"===t[0]?1:"Unassigned"===e[0]?-1:t[0].localeCompare(e[0]))}_getGroupedByLabel(){const t=this._getFilteredAutomations(),e={};return t.forEach(t=>{t.labels&&0!==t.labels.length?t.labels.forEach(s=>{const i=this._getLabelName(s);e[i]||(e[i]=[]),e[i].push(t)}):(e.Unlabeled||(e.Unlabeled=[]),e.Unlabeled.push(t))}),Object.entries(e).sort((t,e)=>"Unlabeled"===t[0]?1:"Unlabeled"===e[0]?-1:t[0].localeCompare(e[0]))}_getPaused(){const t=this.hass?.states["sensor.autosnooze_snoozed_automations"];return t?.attributes?.paused_automations||{}}_getScheduled(){const t=this.hass?.states["sensor.autosnooze_snoozed_automations"];return t?.attributes?.scheduled_snoozes||{}}_formatDateTime(t){return new Date(t).toLocaleString(void 0,{month:"short",day:"numeric",hour:"2-digit",minute:"2-digit"})}_formatCountdown(t){const e=new Date(t).getTime()-Date.now();if(e<=0)return"Waking up...";const s=Math.floor(e/864e5),i=Math.floor(e%864e5/36e5),o=Math.floor(e%36e5/6e4),r=Math.floor(e%6e4/1e3);return s>0?`${s}d ${i}h ${o}m`:i>0?`${i}h ${o}m ${r}s`:`${o}m ${r}s`}_toggleSelection(t){this._selected.includes(t)?this._selected=this._selected.filter(e=>e!==t):this._selected=[...this._selected,t]}_toggleGroupExpansion(t){this._expandedGroups={...this._expandedGroups,[t]:!this._expandedGroups[t]}}_selectGroup(t){const e=t.map(t=>t.id),s=e.every(t=>this._selected.includes(t));this._selected=s?this._selected.filter(t=>!e.includes(t)):[...new Set([...this._selected,...e])]}_setDuration(t){this._duration=6e4*t;const e=Math.floor(t/1440),s=Math.floor(t%1440/60),i=t%60;this._customDuration={days:e,hours:s,minutes:i};const o=[];e>0&&o.push(`${e}d`),s>0&&o.push(`${s}h`),i>0&&o.push(`${i}m`),this._customDurationInput=o.join(" ")||"30m"}_updateCustomDuration(){const{days:t,hours:e,minutes:s}=this._customDuration,i=1440*t+60*e+s;this._duration=6e4*i}_parseDurationInput(t){const e=t.toLowerCase().replace(/\s+/g,"");if(!e)return null;let s=0,i=0,o=0;const r=e.match(/(\d+)\s*d/),a=e.match(/(\d+)\s*h/),n=e.match(/(\d+)\s*m/);if(r&&(s=parseInt(r[1],10)),a&&(i=parseInt(a[1],10)),n&&(o=parseInt(n[1],10)),!r&&!a&&!n){const t=parseInt(e,10);if(isNaN(t)||!(t>0))return null;o=t}return 0===s&&0===i&&0===o?null:{days:s,hours:i,minutes:o}}_handleDurationInput(t){this._customDurationInput=t;const e=this._parseDurationInput(t);e&&(this._customDuration=e,this._updateCustomDuration())}_getDurationPreview(){const t=this._parseDurationInput(this._customDurationInput);return t?this._formatDuration(t.days,t.hours,t.minutes):""}_isDurationValid(){return null!==this._parseDurationInput(this._customDurationInput)}_showToast(t){const e=document.createElement("div");e.className="toast",e.textContent=t,this.shadowRoot?.appendChild(e),setTimeout(()=>{e.style.animation="slideUp 0.3s ease-out reverse",setTimeout(()=>e.remove(),300)},3e3)}async _snooze(){if(0!==this._selected.length&&!this._loading){if(this._scheduleMode){if(!this._resumeAt)return void this._showToast("Please set a resume time")}else if(0===this._duration)return;this._loading=!0;try{const t=this._selected.length;let e;if(this._scheduleMode){const s={entity_id:this._selected,resume_at:this._resumeAt};this._disableAt&&(s.disable_at=this._disableAt),await this.hass.callService("autosnooze","pause",s),e=this._disableAt?`Scheduled ${t} automation${1!==t?"s":""} to snooze`:`Paused ${t} automation${1!==t?"s":""} until ${this._formatDateTime(this._resumeAt)}`}else{const{days:s,hours:i,minutes:o}=this._customDuration;await this.hass.callService("autosnooze","pause",{entity_id:this._selected,days:s,hours:i,minutes:o});e=`Paused ${t} automation${1!==t?"s":""} for ${this._formatDuration(s,i,o)}`}this._showToast(e),this._selected=[],this._disableAt="",this._resumeAt=""}catch(t){console.error("Snooze failed:",t),this._showToast("Failed to pause automations")}this._loading=!1}}_formatDuration(t,e,s){const i=[];return t>0&&i.push(`${t} day${1!==t?"s":""}`),e>0&&i.push(`${e} hour${1!==e?"s":""}`),s>0&&i.push(`${s} minute${1!==s?"s":""}`),i.join(", ")}async _wake(t){try{await this.hass.callService("autosnooze","cancel",{entity_id:t}),this._showToast("Automation resumed")}catch(t){console.error("Wake failed:",t),this._showToast("Failed to resume automation")}}async _wakeAll(){try{await this.hass.callService("autosnooze","cancel_all",{}),this._showToast("All automations resumed")}catch(t){console.error("Wake all failed:",t),this._showToast("Failed to resume automations")}}async _cancelScheduled(t){try{await this.hass.callService("autosnooze","cancel_scheduled",{entity_id:t}),this._showToast("Scheduled snooze cancelled")}catch(t){console.error("Cancel scheduled failed:",t),this._showToast("Failed to cancel scheduled snooze")}}_renderSelectionList(){const t=this._getFilteredAutomations();if("all"===this._filterTab)return 0===t.length?H`<div class="list-empty">No automations found</div>`:t.map(t=>H`
+  `;_getAutomations(){if(!this.hass?.states)return[];if(!this._debugLogged){if(this._debugLogged=!0,console.log("[AutoSnooze] Card version:",rt),console.log("[AutoSnooze] hass.entities available:",!!this.hass.entities,"count:",this.hass.entities?Object.keys(this.hass.entities).length:0),console.log("[AutoSnooze] hass.areas available:",!!this.hass.areas,"count:",this.hass.areas?Object.keys(this.hass.areas).length:0),console.log("[AutoSnooze] Label registry (fetched separately):",Object.keys(this._labelRegistry).length,"labels"),this.hass.entities){const t=Object.keys(this.hass.entities).find(t=>t.startsWith("automation."));t&&console.log("[AutoSnooze] Sample automation entity:",t,this.hass.entities[t])}this.hass.areas&&Object.keys(this.hass.areas).length>0&&console.log("[AutoSnooze] Areas:",Object.entries(this.hass.areas).map(([t,e])=>`${t}: ${e.name}`).join(", "))}return Object.keys(this.hass.states).filter(t=>t.startsWith("automation.")).map(t=>{const e=this.hass.states[t],i=this.hass.entities?.[t];return{id:t,name:e.attributes.friendly_name||t.replace("automation.",""),area_id:i?.area_id||null,labels:i?.labels||[]}}).sort((t,e)=>t.name.localeCompare(e.name))}_getFilteredAutomations(){const t=this._getAutomations(),e=this._search.toLowerCase();let i=t;return e&&(i=t.filter(t=>t.name.toLowerCase().includes(e)||t.id.toLowerCase().includes(e))),i}_getAreaName(t){if(!t)return"Unassigned";const e=this.hass.areas?.[t];return e?.name?e.name:t.replace(/_/g," ").replace(/\b\w/g,t=>t.toUpperCase())}_getLabelName(t){const e=this._labelRegistry[t];return e?.name?e.name:t.replace(/_/g," ").replace(/\b\w/g,t=>t.toUpperCase())}_getGroupedByArea(){const t=this._getFilteredAutomations(),e={};return t.forEach(t=>{const i=this._getAreaName(t.area_id);e[i]||(e[i]=[]),e[i].push(t)}),Object.entries(e).sort((t,e)=>"Unassigned"===t[0]?1:"Unassigned"===e[0]?-1:t[0].localeCompare(e[0]))}_getGroupedByLabel(){const t=this._getFilteredAutomations(),e={};return t.forEach(t=>{t.labels&&0!==t.labels.length?t.labels.forEach(i=>{const s=this._getLabelName(i);e[s]||(e[s]=[]),e[s].push(t)}):(e.Unlabeled||(e.Unlabeled=[]),e.Unlabeled.push(t))}),Object.entries(e).sort((t,e)=>"Unlabeled"===t[0]?1:"Unlabeled"===e[0]?-1:t[0].localeCompare(e[0]))}_getAreaCount(){const t=this._getAutomations(),e=new Set;return t.forEach(t=>{t.area_id&&e.add(t.area_id)}),e.size}_getLabelCount(){const t=this._getAutomations(),e=new Set;return t.forEach(t=>{t.labels&&t.labels.length>0&&t.labels.forEach(t=>e.add(t))}),e.size}_selectAllVisible(){const t=this._getFilteredAutomations().map(t=>t.id),e=t.every(t=>this._selected.includes(t));this._selected=e?this._selected.filter(e=>!t.includes(e)):[...new Set([...this._selected,...t])]}_clearSelection(){this._selected=[]}_getPaused(){const t=this.hass?.states["sensor.autosnooze_snoozed_automations"];return t?.attributes?.paused_automations||{}}_getScheduled(){const t=this.hass?.states["sensor.autosnooze_snoozed_automations"];return t?.attributes?.scheduled_snoozes||{}}_formatDateTime(t){return new Date(t).toLocaleString(void 0,{month:"short",day:"numeric",hour:"2-digit",minute:"2-digit"})}_formatCountdown(t){const e=new Date(t).getTime()-Date.now();if(e<=0)return"Waking up...";const i=Math.floor(e/864e5),s=Math.floor(e%864e5/36e5),o=Math.floor(e%36e5/6e4),r=Math.floor(e%6e4/1e3);return i>0?`${i}d ${s}h ${o}m`:s>0?`${s}h ${o}m ${r}s`:`${o}m ${r}s`}_toggleSelection(t){this._selected.includes(t)?this._selected=this._selected.filter(e=>e!==t):this._selected=[...this._selected,t]}_toggleGroupExpansion(t){this._expandedGroups={...this._expandedGroups,[t]:!this._expandedGroups[t]}}_selectGroup(t){const e=t.map(t=>t.id),i=e.every(t=>this._selected.includes(t));this._selected=i?this._selected.filter(t=>!e.includes(t)):[...new Set([...this._selected,...e])]}_setDuration(t){this._duration=6e4*t;const e=Math.floor(t/1440),i=Math.floor(t%1440/60),s=t%60;this._customDuration={days:e,hours:i,minutes:s};const o=[];e>0&&o.push(`${e}d`),i>0&&o.push(`${i}h`),s>0&&o.push(`${s}m`),this._customDurationInput=o.join(" ")||"30m"}_updateCustomDuration(){const{days:t,hours:e,minutes:i}=this._customDuration,s=1440*t+60*e+i;this._duration=6e4*s}_parseDurationInput(t){const e=t.toLowerCase().replace(/\s+/g,"");if(!e)return null;let i=0,s=0,o=0;const r=e.match(/(\d+)\s*d/),a=e.match(/(\d+)\s*h/),n=e.match(/(\d+)\s*m/);if(r&&(i=parseInt(r[1],10)),a&&(s=parseInt(a[1],10)),n&&(o=parseInt(n[1],10)),!r&&!a&&!n){const t=parseInt(e,10);if(isNaN(t)||!(t>0))return null;o=t}return 0===i&&0===s&&0===o?null:{days:i,hours:s,minutes:o}}_handleDurationInput(t){this._customDurationInput=t;const e=this._parseDurationInput(t);e&&(this._customDuration=e,this._updateCustomDuration())}_getDurationPreview(){const t=this._parseDurationInput(this._customDurationInput);return t?this._formatDuration(t.days,t.hours,t.minutes):""}_isDurationValid(){return null!==this._parseDurationInput(this._customDurationInput)}_showToast(t){const e=document.createElement("div");e.className="toast",e.textContent=t,this.shadowRoot?.appendChild(e),setTimeout(()=>{e.style.animation="slideUp 0.3s ease-out reverse",setTimeout(()=>e.remove(),300)},3e3)}async _snooze(){if(0!==this._selected.length&&!this._loading){if(this._scheduleMode){if(!this._resumeAt)return void this._showToast("Please set a resume time")}else if(0===this._duration)return;this._loading=!0;try{const t=this._selected.length;let e;if(this._scheduleMode){const i={entity_id:this._selected,resume_at:this._resumeAt};this._disableAt&&(i.disable_at=this._disableAt),await this.hass.callService("autosnooze","pause",i),e=this._disableAt?`Scheduled ${t} automation${1!==t?"s":""} to snooze`:`Paused ${t} automation${1!==t?"s":""} until ${this._formatDateTime(this._resumeAt)}`}else{const{days:i,hours:s,minutes:o}=this._customDuration;await this.hass.callService("autosnooze","pause",{entity_id:this._selected,days:i,hours:s,minutes:o});e=`Paused ${t} automation${1!==t?"s":""} for ${this._formatDuration(i,s,o)}`}this._showToast(e),this._selected=[],this._disableAt="",this._resumeAt=""}catch(t){console.error("Snooze failed:",t),this._showToast("Failed to pause automations")}this._loading=!1}}_formatDuration(t,e,i){const s=[];return t>0&&s.push(`${t} day${1!==t?"s":""}`),e>0&&s.push(`${e} hour${1!==e?"s":""}`),i>0&&s.push(`${i} minute${1!==i?"s":""}`),s.join(", ")}async _wake(t){try{await this.hass.callService("autosnooze","cancel",{entity_id:t}),this._showToast("Automation resumed")}catch(t){console.error("Wake failed:",t),this._showToast("Failed to resume automation")}}async _wakeAll(){try{await this.hass.callService("autosnooze","cancel_all",{}),this._showToast("All automations resumed")}catch(t){console.error("Wake all failed:",t),this._showToast("Failed to resume automations")}}async _cancelScheduled(t){try{await this.hass.callService("autosnooze","cancel_scheduled",{entity_id:t}),this._showToast("Scheduled snooze cancelled")}catch(t){console.error("Cancel scheduled failed:",t),this._showToast("Failed to cancel scheduled snooze")}}_renderSelectionList(){const t=this._getFilteredAutomations();if("all"===this._filterTab)return 0===t.length?L`<div class="list-empty">No automations found</div>`:t.map(t=>{const e=t.area_id?this._getAreaName(t.area_id):null,i=t.labels&&t.labels.length>0?t.labels.map(t=>this._getLabelName(t)).join(", "):null,s=[e,i].filter(Boolean).join(" • ");return L`
           <div
             class="list-item ${this._selected.includes(t.id)?"selected":""}"
             @click=${()=>this._toggleSelection(t.id)}
@@ -497,22 +568,29 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
             <ha-icon
               icon=${this._selected.includes(t.id)?"mdi:checkbox-marked":"mdi:checkbox-blank-outline"}
             ></ha-icon>
-            <span class="list-item-name">${t.name}</span>
+            <div class="list-item-content">
+              <div class="list-item-name">${t.name}</div>
+              ${s?L`<div class="list-item-meta">
+                    ${e?L`<ha-icon icon="mdi:home-outline"></ha-icon>${e}`:""}
+                    ${e&&i?" • ":""}
+                    ${i?L`<ha-icon icon="mdi:label-outline"></ha-icon>${i}`:""}
+                  </div>`:""}
+            </div>
           </div>
-        `);const e="areas"===this._filterTab?this._getGroupedByArea():this._getGroupedByLabel();return 0===e.length?H`<div class="list-empty">No automations found</div>`:e.map(([t,e])=>{const s=!1!==this._expandedGroups[t],i=e.every(t=>this._selected.includes(t.id));return H`
+        `});const e="areas"===this._filterTab?this._getGroupedByArea():this._getGroupedByLabel();return 0===e.length?L`<div class="list-empty">No automations found</div>`:e.map(([t,e])=>{const i=!1!==this._expandedGroups[t],s=e.every(t=>this._selected.includes(t.id)),o=e.some(t=>this._selected.includes(t.id))&&!s;return L`
         <div
-          class="group-header ${s?"expanded":""}"
+          class="group-header ${i?"expanded":""}"
           @click=${()=>this._toggleGroupExpansion(t)}
         >
           <ha-icon icon="mdi:chevron-right"></ha-icon>
           <span>${t}</span>
           <span class="group-badge">${e.length}</span>
           <ha-icon
-            icon=${i?"mdi:checkbox-marked":"mdi:checkbox-blank-outline"}
+            icon=${s?"mdi:checkbox-marked":o?"mdi:checkbox-intermediate":"mdi:checkbox-blank-outline"}
             @click=${t=>{t.stopPropagation(),this._selectGroup(e)}}
           ></ha-icon>
         </div>
-        ${s?e.map(t=>H`
+        ${i?e.map(t=>{const e="areas"===this._filterTab&&t.labels&&t.labels.length>0,i="labels"===this._filterTab&&t.area_id,s=e?t.labels.map(t=>this._getLabelName(t)).join(", "):i?this._getAreaName(t.area_id):null;return L`
                 <div
                   class="list-item ${this._selected.includes(t.id)?"selected":""}"
                   @click=${()=>this._toggleSelection(t.id)}
@@ -520,16 +598,23 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
                   <ha-icon
                     icon=${this._selected.includes(t.id)?"mdi:checkbox-marked":"mdi:checkbox-blank-outline"}
                   ></ha-icon>
-                  <span class="list-item-name">${t.name}</span>
+                  <div class="list-item-content">
+                    <div class="list-item-name">${t.name}</div>
+                    ${s?L`<div class="list-item-meta">
+                          ${e?L`<ha-icon icon="mdi:label-outline"></ha-icon>`:""}
+                          ${i?L`<ha-icon icon="mdi:home-outline"></ha-icon>`:""}
+                          ${s}
+                        </div>`:""}
+                  </div>
                 </div>
-              `):""}
-      `})}render(){const t=this._getPaused(),e=Object.keys(t).length,s=this._getScheduled(),i=Object.keys(s).length,o=[{label:"30m",minutes:30},{label:"1h",minutes:60},{label:"4h",minutes:240},{label:"1 day",minutes:1440}],r=1440*this._customDuration.days+60*this._customDuration.hours+this._customDuration.minutes,a=o.find(t=>t.minutes===r),n=this._getDurationPreview(),l=this._isDurationValid();return H`
+              `}):""}
+      `})}render(){const t=this._getPaused(),e=Object.keys(t).length,i=this._getScheduled(),s=Object.keys(i).length,o=[{label:"30m",minutes:30},{label:"1h",minutes:60},{label:"4h",minutes:240},{label:"1 day",minutes:1440}],r=1440*this._customDuration.days+60*this._customDuration.hours+this._customDuration.minutes,a=o.find(t=>t.minutes===r),n=this._getDurationPreview(),l=this._isDurationValid();return L`
       <ha-card>
         <div class="header">
           <ha-icon icon="mdi:sleep"></ha-icon>
           ${this.config?.title||"AutoSnooze"}
-          ${e>0||i>0?H`<span class="status-summary"
-                >${e>0?`${e} active`:""}${e>0&&i>0?", ":""}${i>0?`${i} scheduled`:""}</span
+          ${e>0||s>0?L`<span class="status-summary"
+                >${e>0?`${e} active`:""}${e>0&&s>0?", ":""}${s>0?`${s} scheduled`:""}</span
               >`:""}
         </div>
 
@@ -542,18 +627,21 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
               @click=${()=>this._filterTab="all"}
             >
               All
+              <span class="tab-count">${this._getAutomations().length}</span>
             </button>
             <button
               class="tab ${"areas"===this._filterTab?"active":""}"
               @click=${()=>this._filterTab="areas"}
             >
               Areas
+              <span class="tab-count">${this._getAreaCount()}</span>
             </button>
             <button
               class="tab ${"labels"===this._filterTab?"active":""}"
               @click=${()=>this._filterTab="labels"}
             >
               Labels
+              <span class="tab-count">${this._getLabelCount()}</span>
             </button>
           </div>
 
@@ -566,6 +654,17 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
               @input=${t=>this._search=t.target.value}
             />
           </div>
+
+          <!-- Selection Actions -->
+          ${this._getFilteredAutomations().length>0?L`
+                <div class="selection-actions">
+                  <span>${this._selected.length} of ${this._getFilteredAutomations().length} selected</span>
+                  <button class="select-all-btn" @click=${()=>this._selectAllVisible()}>
+                    ${this._getFilteredAutomations().every(t=>this._selected.includes(t.id))?"Deselect All":"Select All"}
+                  </button>
+                  ${this._selected.length>0?L`<button class="select-all-btn" @click=${()=>this._clearSelection()}>Clear</button>`:""}
+                </div>
+              `:""}
 
           <!-- Selection List -->
           <div class="selection-list">${this._renderSelectionList()}</div>
@@ -582,7 +681,7 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
             />
           </div>
 
-          ${this._scheduleMode?H`
+          ${this._scheduleMode?L`
                 <!-- Schedule Datetime Inputs -->
                 <div class="schedule-inputs">
                   <div class="datetime-field">
@@ -602,11 +701,12 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
                     />
                   </div>
                 </div>
-              `:H`
+              `:L`
                 <!-- Duration Selector -->
                 <div class="duration-selector">
+                  <div class="duration-section-header">Snooze Duration</div>
                   <div class="duration-pills">
-                    ${o.map(t=>H`
+                    ${o.map(t=>L`
                         <button
                           class="pill ${a===t?"active":""}"
                           @click=${()=>this._setDuration(t.minutes)}
@@ -620,12 +720,12 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
                     <input
                       type="text"
                       class="duration-input ${l?"":"invalid"}"
-                      placeholder="e.g. 2h30m, 1d, 45m"
+                      placeholder="Custom: 2h30m, 1d, 45m..."
                       .value=${this._customDurationInput}
                       @input=${t=>this._handleDurationInput(t.target.value)}
                     />
                   </div>
-                  ${n&&l?H`<div class="duration-preview">Duration: ${n}</div>`:H`<div class="duration-help">Format: 30m, 1h, 4h, 1d, 2h30m, 1d2h</div>`}
+                  ${n&&l?L`<div class="duration-preview">Duration: ${n}</div>`:L`<div class="duration-help">Enter custom duration: 30m, 2h, 4h30m, 1d, 1d2h</div>`}
                 </div>
               `}
 
@@ -640,14 +740,14 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
         </div>
 
         <!-- Section B: Active Snoozes -->
-        ${e>0?H`
+        ${e>0?L`
               <div class="snooze-list">
                 <div class="list-header">
                   <ha-icon icon="mdi:bell-sleep"></ha-icon>
                   Snoozed Automations (${e})
                 </div>
 
-                ${Object.entries(t).map(([t,e])=>H`
+                ${Object.entries(t).map(([t,e])=>L`
                     <div class="paused-item">
                       <ha-icon class="paused-icon" icon="mdi:sleep"></ha-icon>
                       <div class="paused-info">
@@ -664,7 +764,7 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
                     </div>
                   `)}
 
-                ${e>1?H`
+                ${e>1?L`
                       <button class="wake-all" @click=${this._wakeAll}>
                         Wake All
                       </button>
@@ -673,14 +773,14 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
             `:""}
 
         <!-- Section C: Scheduled Snoozes -->
-        ${i>0?H`
+        ${s>0?L`
               <div class="scheduled-list">
                 <div class="list-header">
                   <ha-icon icon="mdi:calendar-clock"></ha-icon>
-                  Scheduled Snoozes (${i})
+                  Scheduled Snoozes (${s})
                 </div>
 
-                ${Object.entries(s).map(([t,e])=>H`
+                ${Object.entries(i).map(([t,e])=>L`
                     <div class="scheduled-item">
                       <ha-icon class="scheduled-icon" icon="mdi:clock-outline"></ha-icon>
                       <div class="paused-info">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autosnooze",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "AutoSnooze - Temporarily pause Home Assistant automations",
   "main": "custom_components/autosnooze/www/autosnooze-card.js",
   "scripts": {


### PR DESCRIPTION
- Add tab counts showing number of automations, areas, and labels
- Add selection actions bar with Select All/Deselect All/Clear buttons
- Show area and label metadata in the All tab automation list
- Add intermediate checkbox state for partially selected groups
- Show complementary info in grouped views (labels when in Areas, area when in Labels)
- Add "Snooze Duration" section header for clarity
- Improve duration input placeholder text
- Update to version 2.8.0