### PR TITLE
Add deploy.sh and Python cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
 package-lock.json
-deploy.sh
 __pycache__/
 *.pyc

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "AutoSnooze",
   "content_in_root": false,
-  "render_readme": true
+  "render_readme": true,
+  "zip_release": false
 }


### PR DESCRIPTION
Support local development workflow with deploy script that syncs
changes directly to remote Home Assistant instance.