### PR TITLE
Fix: Match any autosnooze URL format for resource update

### DIFF
--- a/custom_components/autosnooze/__init__.py
+++ b/custom_components/autosnooze/__init__.py
@@ -223,12 +223,12 @@ async def _async_register_lovelace_resource(hass: HomeAssistant) -> None:
         _LOGGER.debug("Lovelace resources not available (YAML mode?)")
         return
 
-    # Check if already registered (with or without version query param)
+    # Check if already registered (any format: query param, path-based, or base URL)
     existing_resource = None
     for resource in resources.async_items():
         url = resource.get("url", "")
-        # Match any autosnooze card URL (base path, ignoring query params)
-        if url.startswith(CARD_URL):
+        # Match any autosnooze card URL (handles both old path-based and new query-param formats)
+        if f"/{DOMAIN}/autosnooze-card" in url:
             existing_resource = resource
             break
 


### PR DESCRIPTION
## Summary

The previous matching logic only matched query-param URLs, not the old path-based URLs (`/autosnooze/autosnooze-card-2.9.0.js`). This caused a new resource to be created instead of updating the existing one, leaving the old 404 resource in place - making the card disappear.

Now matches any URL containing `/autosnooze/autosnooze-card` to handle both old and new formats during migration.

## Test plan

- [ ] Restart HA with old path-based resource URL
- [ ] Verify resource gets updated to new query-param format
- [ ] Verify card loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)