### PR TITLE
Fix: Use /api/ prefix for reverse proxy compatibility

### DIFF
--- a/custom_components/autosnooze/__init__.py
+++ b/custom_components/autosnooze/__init__.py
@@ -33,9 +33,9 @@ with open(MANIFEST_PATH, encoding="utf-8") as manifest_file:
 VERSION = MANIFEST.get("version", "0.0.0")
 
 CARD_PATH = Path(__file__).parent / "www" / "autosnooze-card.js"
-# Query param versioning - standard approach in HA ecosystem
-CARD_URL = f"/{DOMAIN}/autosnooze-card.js"
-CARD_URL_VERSIONED = f"/{DOMAIN}/autosnooze-card.js?v={VERSION}"
+# Use /api/ prefix for compatibility with reverse proxies (Cloudflare, Nginx, etc.)
+CARD_URL = f"/api/{DOMAIN}/static/autosnooze-card.js"
+CARD_URL_VERSIONED = f"/api/{DOMAIN}/static/autosnooze-card.js?v={VERSION}"
 
 
 @dataclass

--- a/tests/test_card_bundle.py
+++ b/tests/test_card_bundle.py
@@ -433,17 +433,19 @@ class TestCDNCacheBusting:
         - Used by HACS (?hacstag=TIMESTAMP)
         - Used by card-mod, mini-graph-card, and most community cards
         - No URL path changes = no backwards compatibility issues
+
+        Uses /api/ prefix for reverse proxy compatibility (Cloudflare, Nginx, etc.)
         """
         content = self.INIT_PATH.read_text()
 
-        # Base URL should not include version
-        assert 'CARD_URL = f"/{DOMAIN}/autosnooze-card.js"' in content, (
-            "REGRESSION: CARD_URL should be the base path without version. "
+        # Base URL should use /api/ prefix for reverse proxy compatibility
+        assert 'CARD_URL = f"/api/{DOMAIN}/static/autosnooze-card.js"' in content, (
+            "REGRESSION: CARD_URL should use /api/ prefix for reverse proxy compatibility. "
             "Version should be in query param via CARD_URL_VERSIONED."
         )
 
         # Should have versioned URL with query param
-        assert 'CARD_URL_VERSIONED = f"/{DOMAIN}/autosnooze-card.js?v={VERSION}"' in content, (
+        assert 'CARD_URL_VERSIONED = f"/api/{DOMAIN}/static/autosnooze-card.js?v={VERSION}"' in content, (
             "REGRESSION: CARD_URL_VERSIONED should use ?v= query param. "
             "This is the HA ecosystem standard for cache busting."
         )


### PR DESCRIPTION
## Summary
- Changed card static path from `/autosnooze/` to `/api/autosnooze/static/`
- Fixes card not loading when accessed through Cloudflare Tunnel, Nginx, or other reverse proxies

## Root Cause
Reverse proxies (Cloudflare Tunnel, Nginx, etc.) only forward known HA paths by default. The `/autosnooze/` path wasn't being proxied, resulting in 404 errors when loading the card.

The `/api/` prefix is always forwarded since it's required for HA's core API functionality.

## Test plan
- [ ] Delete existing Lovelace resource for autosnooze
- [ ] Restart Home Assistant
- [ ] Verify card loads through Cloudflare Tunnel / reverse proxy
- [ ] Verify card appears in Lovelace card picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)