### PR TITLE
Fix: Use root-level path like browser_mod to avoid conflicts

### DIFF
--- a/custom_components/autosnooze/__init__.py
+++ b/custom_components/autosnooze/__init__.py
@@ -33,9 +33,9 @@ with open(MANIFEST_PATH, encoding="utf-8") as manifest_file:
 VERSION = MANIFEST.get("version", "0.0.0")
 
 CARD_PATH = Path(__file__).parent / "www" / "autosnooze-card.js"
-# Use /api/ prefix for compatibility with reverse proxies (Cloudflare, Nginx, etc.)
-CARD_URL = f"/api/{DOMAIN}/static/autosnooze-card.js"
-CARD_URL_VERSIONED = f"/api/{DOMAIN}/static/autosnooze-card.js?v={VERSION}"
+# Root-level path like browser_mod uses - avoids /api/ conflicts and works with proxies
+CARD_URL = "/autosnooze-card.js"
+CARD_URL_VERSIONED = f"/autosnooze-card.js?v={VERSION}"
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Changed card URL from `/api/autosnooze/static/autosnooze-card.js` to `/autosnooze-card.js`
- Matches the pattern used by browser_mod (`/browser_mod.js`)

## Problem
The `/api/` prefix was causing conflicts with other cards (Mushroom cards stopped working).

## Solution
Use a root-level path like browser_mod does. This:
1. Works through reverse proxies (Cloudflare Tunnel)
2. Doesn't conflict with HA's actual API routes
3. Is the proven pattern used by browser_mod

## Test plan
- [ ] Delete old Lovelace resources for autosnooze
- [ ] Restart Home Assistant
- [ ] Verify autosnooze card loads
- [ ] Verify Mushroom and other cards still work
- [ ] Verify works through Cloudflare Tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)