### PR TITLE
Improve: Use HACS pattern for Lovelace resource registration

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -880,47 +880,15 @@ class TestAsyncResume:
 class TestLovelaceResourceSafety:
     """Regression tests for Lovelace resource registration.
 
-    These tests ensure the integration never modifies or deletes
-    existing Lovelace resources, which could break other custom cards.
+    These tests ensure the integration only modifies its OWN resources
+    and never touches other custom cards' resources.
     """
 
-    def test_register_function_never_updates_existing_resources(self) -> None:
-        """Verify source code doesn't call async_update_item.
+    def test_uses_namespace_prefix_pattern(self) -> None:
+        """Verify resource matching uses namespace prefix like HACS.
 
-        REGRESSION: Previous versions could overwrite other cards' resources.
-        """
-        import os
-        init_path = os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "custom_components",
-            "autosnooze",
-            "__init__.py"
-        )
-        with open(init_path, "r") as f:
-            source = f.read()
-
-        # Extract the _async_register_lovelace_resource function
-        func_match = source.find("async def _async_register_lovelace_resource")
-        assert func_match != -1, "Function not found"
-
-        # Find next function to get end boundary
-        next_func = source.find("\nasync def ", func_match + 1)
-        if next_func == -1:
-            next_func = len(source)
-
-        func_body = source[func_match:next_func]
-
-        # Should NOT contain async_update_item (modifying resources is dangerous)
-        assert "async_update_item" not in func_body, (
-            "SAFETY VIOLATION: _async_register_lovelace_resource must not "
-            "call async_update_item as it can corrupt other resources"
-        )
-
-    def test_register_function_never_deletes_resources(self) -> None:
-        """Verify source code doesn't call async_delete_item.
-
-        REGRESSION: Ensure we never delete resources.
+        REGRESSION: Previous code used wrong pattern that never matched,
+        causing duplicate resources on every restart.
         """
         import os
         init_path = os.path.join(
@@ -943,17 +911,45 @@ class TestLovelaceResourceSafety:
 
         func_body = source[func_match:next_func]
 
-        # Should NOT contain async_delete_item
+        # Must use startswith for namespace matching (like HACS)
+        assert "startswith" in func_body, (
+            "Resource matching must use startswith() for namespace prefix matching"
+        )
+        # Must use CARD_URL as namespace (not a broken pattern)
+        assert "CARD_URL" in func_body, (
+            "Must use CARD_URL as the namespace for matching"
+        )
+
+    def test_never_deletes_resources(self) -> None:
+        """Verify source code doesn't call async_delete_item."""
+        import os
+        init_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+            "autosnooze",
+            "__init__.py"
+        )
+        with open(init_path, "r") as f:
+            source = f.read()
+
+        func_match = source.find("async def _async_register_lovelace_resource")
+        assert func_match != -1, "Function not found"
+
+        next_func = source.find("\nasync def ", func_match + 1)
+        if next_func == -1:
+            next_func = len(source)
+
+        func_body = source[func_match:next_func]
+
         assert "async_delete_item" not in func_body, (
-            "SAFETY VIOLATION: _async_register_lovelace_resource must not "
-            "call async_delete_item"
+            "SAFETY VIOLATION: Must never delete resources"
         )
 
-    def test_register_function_only_creates_when_not_exists(self) -> None:
-        """Verify the function returns early when resource already exists.
+    def test_references_hacs_pattern(self) -> None:
+        """Verify the function references HACS as the source pattern.
 
-        REGRESSION: The function should check for existing resources
-        and return without modification if found.
+        This ensures future developers understand where the pattern came from.
         """
         import os
         init_path = os.path.join(
@@ -966,7 +962,6 @@ class TestLovelaceResourceSafety:
         with open(init_path, "r") as f:
             source = f.read()
 
-        # Extract the _async_register_lovelace_resource function
         func_match = source.find("async def _async_register_lovelace_resource")
         assert func_match != -1, "Function not found"
 
@@ -976,21 +971,13 @@ class TestLovelaceResourceSafety:
 
         func_body = source[func_match:next_func]
 
-        # Must check for existing autosnooze resource
-        assert "autosnooze-card" in func_body, (
-            "Function must check for existing autosnooze-card resources"
+        # Should reference HACS pattern
+        assert "HACS" in func_body or "hacs" in func_body.lower(), (
+            "Function should reference HACS as the source of the pattern"
         )
 
-        # Must have early return when resource exists
-        assert "return" in func_body.split("async_create_item")[0], (
-            "Function must return early when resource already exists"
-        )
-
-    def test_docstring_documents_safety_guarantee(self) -> None:
-        """Verify the function documents its safety guarantee.
-
-        This ensures future developers understand the constraints.
-        """
+    def test_handles_ha_version_compatibility(self) -> None:
+        """Verify version-aware resource access for HA 2025.2.0+."""
         import os
         init_path = os.path.join(
             os.path.dirname(__file__),
@@ -1002,7 +989,6 @@ class TestLovelaceResourceSafety:
         with open(init_path, "r") as f:
             source = f.read()
 
-        # Extract the _async_register_lovelace_resource function
         func_match = source.find("async def _async_register_lovelace_resource")
         assert func_match != -1, "Function not found"
 
@@ -1012,7 +998,7 @@ class TestLovelaceResourceSafety:
 
         func_body = source[func_match:next_func]
 
-        # Should document the safety behavior
-        assert "SAFETY" in func_body or "never modifies" in func_body.lower(), (
-            "Function should document its safety guarantees in docstring"
+        # Should use getattr for version-aware access
+        assert "getattr" in func_body, (
+            "Must use getattr for version-aware resource access"
         )


### PR DESCRIPTION
## Summary

Follow HACS's proven pattern for Lovelace resource management, enabling automatic version updates while ensuring safety.

## Changes

- Use `url.startswith(CARD_URL)` namespace prefix matching (like HACS)
- Add version-aware resource access for HA 2025.2.0+ compatibility
- Update existing resource URL when version changes
- Add fallback for older HA installations

## Why This Matters

The previous "create-only" approach was safe but wouldn't update the resource URL when the integration version changed. This follows HACS's battle-tested pattern that:

1. Uses `startswith()` to precisely identify OUR resource
2. Only modifies resources that match our namespace
3. Never touches other cards' resources

## References

- [HACS PR #4402](https://github.com/hacs/integration/pull/4402) - Handle deprecation in lovelace data

## Test plan

- [x] All JavaScript tests pass (50 tests)
- [x] Regression tests enforce HACS pattern (startswith, CARD_URL namespace)
- [x] No async_delete_item calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)