### PR TITLE
Add unit tests for automation categories feature

### DIFF
--- a/tests/test_defects.spec.js
+++ b/tests/test_defects.spec.js
@@ -84,15 +84,16 @@ describe('Defect #2: Categories Should Pull from HA Entity Registry', () => {
     });
 
     test('_getAutomations should fetch category from entity registry', () => {
-      // Like how area_id is fetched from entityEntry, category should be too
+      // Category should be fetched from entity registry (via _entityRegistry)
       const methodMatch = sourceCode.match(/_getAutomations\(\)\s*\{([\s\S]*?)\n  \}/);
       const methodBody = methodMatch ? methodMatch[1] : '';
 
-      // Should include category_id in the returned object from entityEntry
-      const hasCategoryFromEntityEntry = methodBody.includes('category') &&
-                                          methodBody.includes('entityEntry');
+      // Should include category_id from registry entry (fetched via WebSocket)
+      const hasCategoryFromRegistry = methodBody.includes('category') &&
+                                       (methodBody.includes('registryEntry') ||
+                                        methodBody.includes('_entityRegistry'));
 
-      expect(hasCategoryFromEntityEntry).toBe(true);
+      expect(hasCategoryFromRegistry).toBe(true);
     });
 
     test('Category should be stored in automation objects like area_id', () => {


### PR DESCRIPTION
Tests verify the automation categories implementation including:
- Category registry fetching from HA WebSocket
- Category data extraction from entity registry
- Category name resolution with registry lookup
- Category grouping logic with proper sorting
- Categories tab UI and badge display

BUG DOCUMENTED: All automations currently show as "Uncategorized"
because category_id extraction from entityEntry?.categories?.automation
returns null at runtime. Tests document both expected behavior and
current broken state.

34 tests covering structure, behavior simulation, and bug analysis.