### PR TITLE
Debug: Add logging to diagnose category data structure

### DIFF
--- a/src/autosnooze-card.js
+++ b/src/autosnooze-card.js
@@ -200,6 +200,13 @@ class AutomationPauseCard extends LitElement {
         ? entities.filter((e) => e.entity_id.startsWith("automation."))
         : [];
 
+      // Debug: Check if basic list includes categories
+      if (automationEntities.length > 0) {
+        const basicSample = automationEntities.find(e => e.categories) || automationEntities[0];
+        console.log("[AutoSnooze] Basic list entry keys:", Object.keys(basicSample));
+        console.log("[AutoSnooze] Basic list categories:", basicSample.categories);
+      }
+
       // Step 3: Fetch EXTENDED entry for each automation (includes categories)
       // The basic list endpoint doesn't include categories for performance reasons
       const extendedEntries = await Promise.all(
@@ -213,13 +220,24 @@ class AutomationPauseCard extends LitElement {
 
       // Step 4: Build map from extended entries
       const entityMap = {};
+      let categorizedCount = 0;
       extendedEntries.forEach((entity) => {
         entityMap[entity.entity_id] = entity;
+        if (entity.categories && Object.keys(entity.categories).length > 0) {
+          categorizedCount++;
+        }
       });
 
       this._entityRegistry = entityMap;
       this._entityRegistryFetched = true;
-      console.log("[AutoSnooze] Entity registry fetched:", Object.keys(entityMap).length, "automation entities with categories");
+      console.log("[AutoSnooze] Entity registry fetched:", Object.keys(entityMap).length, "automations,", categorizedCount, "with categories");
+
+      // Debug: Log a sample entry to see the data structure
+      if (extendedEntries.length > 0) {
+        const sample = extendedEntries.find(e => e.categories && Object.keys(e.categories).length > 0) || extendedEntries[0];
+        console.log("[AutoSnooze] Sample extended entry keys:", Object.keys(sample));
+        console.log("[AutoSnooze] Sample categories:", sample.categories);
+      }
     } catch (err) {
       console.warn("[AutoSnooze] Failed to fetch entity registry:", err);
     }


### PR DESCRIPTION
## Summary

Adds detailed console logging to diagnose why categories tab shows 0 despite the category registry being fetched successfully (11 categories).

## Problem

User reports seeing `[AutoSnooze] Category registry fetched: 11 categories` but categories still show 0 in the UI.

## Debug Logging Added

The following logs are added to `_fetchEntityRegistry()`:

1. **Basic list entry keys** - Shows what fields the basic `config/entity_registry/list` returns
2. **Basic list categories** - Checks if the basic list already includes categories
3. **Extended entry keys** - Shows what fields `config/entity_registry/get` returns
4. **Sample categories** - Shows the actual categories object structure
5. **Categorized count** - How many automations have categories assigned

## Expected Console Output

```
[AutoSnooze] Basic list entry keys: [...]
[AutoSnooze] Basic list categories: ...
[AutoSnooze] Entity registry fetched: X automations, Y with categories
[AutoSnooze] Sample extended entry keys: [...]
[AutoSnooze] Sample categories: ...
```

## What This Will Reveal

- Whether Home Assistant's entity registry list includes categories
- Whether extended entity entries include categories
- The actual structure of the `categories` object (expected: `{automation: "category_id"}`)

## Test plan

- [ ] Deploy card and open browser console
- [ ] Check debug output to understand data structure
- [ ] Use findings to fix the root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)