### PR TITLE
Fix: Simplify HACS config for integration type

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,4 @@
 {
   "name": "AutoSnooze",
-  "content_in_root": true,
-  "render_readme": true,
-  "filename": "autosnooze-card.js"
+  "render_readme": true
 }


### PR DESCRIPTION
## Summary

HACS download was failing with "No manifest.json file found" error.

## Problem

The hacs.json had plugin-specific settings (`content_in_root`, `filename`) that confused HACS. For integrations, HACS expects `manifest.json` in `custom_components/<domain>/`.

## Fix

Simplified hacs.json to just:
```json
{
  "name": "AutoSnooze",
  "render_readme": true
}
```

HACS will now:
1. Detect this as an integration (finds `custom_components/autosnooze/manifest.json`)
2. Download the full `custom_components/autosnooze/` folder
3. The integration's `__init__.py` registers the Lovelace card automatically

## Test plan

- [ ] HACS can download and install the integration
- [ ] Card appears in Lovelace after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)