### PR TITLE
Fix: Add manifest.json to root for HACS compatibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "autosnooze",
+  "name": "AutoSnooze",
+  "codeowners": [],
+  "config_flow": true,
+  "dependencies": ["frontend", "http", "lovelace"],
+  "documentation": "https://github.com/mossipcams/autosnooze",
+  "integration_type": "service",
+  "iot_class": "local_push",
+  "requirements": [],
+  "version": "2.9.1"
+}


### PR DESCRIPTION
Adds manifest.json to root so HACS can find it regardless of category type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)