### PR TITLE
Fix: Hide automation areas in Categories tab

### DIFF
--- a/src/autosnooze-card.js
+++ b/src/autosnooze-card.js
@@ -1306,10 +1306,10 @@ class AutomationPauseCard extends LitElement {
         </div>
         ${expanded
           ? items.map((a) => {
-              // Areas tab: no metadata (area is the group header, no labels per requirements)
-              // Categories tab: show area as complementary info
+              // Areas tab: no metadata (area is the group header)
+              // Categories tab: no metadata (category is the group header)
               // Labels tab: show area as complementary info
-              const showArea = (this._filterTab === "labels" || this._filterTab === "categories") && a.area_id;
+              const showArea = this._filterTab === "labels" && a.area_id;
               const metaInfo = showArea ? this._getAreaName(a.area_id) : null;
 
               return html`


### PR DESCRIPTION
## Summary
- Remove area metadata display when viewing automations grouped by category
- Areas now only shown as complementary info on the Labels tab
- Keeps the UI cleaner when browsing by category

## Test plan
- [x] All 93 tests pass
- [ ] Verify Categories tab no longer shows area info under automation names
- [ ] Verify Labels tab still shows area info

🤖 Generated with [Claude Code](https://claude.com/claude-code)