### PR TITLE
Fix service call datetime comparison with offset-naive datetimes

### DIFF
--- a/custom_components/autosnooze/manifest.json
+++ b/custom_components/autosnooze/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "service",
   "iot_class": "local_push",
   "requirements": [],
-  "version": "2.9.24"
+  "version": "2.9.25"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autosnooze",
-  "version": "2.9.24",
+  "version": "2.9.25",
   "description": "AutoSnooze - Temporarily pause Home Assistant automations",
   "main": "custom_components/autosnooze/www/autosnooze-card.js",
   "scripts": {

--- a/src/autosnooze-card.js
+++ b/src/autosnooze-card.js
@@ -1,7 +1,7 @@
 import { LitElement, html, css } from "lit";
 
-// Version 2.9.24 - Fix schedule mode date comparison with offset-naive datetimes
-const CARD_VERSION = "2.9.24";
+// Version 2.9.25 - Fix service call datetime comparison with offset-naive datetimes
+const CARD_VERSION = "2.9.25";
 
 // ============================================================================
 // CARD EDITOR


### PR DESCRIPTION
The previous fix (v2.9.24) only addressed datetimes loaded from storage
via from_dict() methods, but missed datetimes coming from service calls.

Root cause: cv.datetime validator uses dt_util.parse_datetime() which
returns offset-naive datetimes when input lacks timezone info. These
were passed directly to _pause_automations() and compared with
dt_util.utcnow() which is always offset-aware, causing TypeError.

Fix:
- Add _ensure_utc_aware() helper for datetime objects (not strings)
- Apply in _pause_automations() as defensive measure
- Apply in all service handlers (handle_pause, handle_pause_by_area,
  handle_pause_by_label) for explicit handling at the source

Bump version to 2.9.25