### PR TITLE
Show start and end dates for schedule-mode snoozes

### DIFF
--- a/custom_components/autosnooze/manifest.json
+++ b/custom_components/autosnooze/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "service",
   "iot_class": "local_push",
   "requirements": [],
-  "version": "2.9.25"
+  "version": "2.9.26"
 }

--- a/custom_components/autosnooze/www/autosnooze-card.js
+++ b/custom_components/autosnooze/www/autosnooze-card.js
@@ -754,9 +754,18 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
                         <div class="paused-name">
                           ${e.friendly_name||t}
                         </div>
-                        <div class="paused-time">
-                          Waking up in: ${this._formatCountdown(e.resume_at)}
-                        </div>
+                        ${e.disable_at?N`
+                              <div class="scheduled-time">
+                                Started: ${this._formatDateTime(e.disable_at)}
+                              </div>
+                              <div class="paused-time">
+                                Resumes: ${this._formatDateTime(e.resume_at)}
+                              </div>
+                            `:N`
+                              <div class="paused-time">
+                                Waking up in: ${this._formatCountdown(e.resume_at)}
+                              </div>
+                            `}
                       </div>
                       <button class="wake-btn" @click=${()=>this._wake(t)}>
                         Wake Now
@@ -802,4 +811,4 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
               </div>
             `:""}
       </ha-card>
-    `}getCardSize(){const t=this._getPaused(),e=this._getScheduled();return 4+Object.keys(t).length+Object.keys(e).length}setConfig(t){this.config=t}}customElements.get("autosnooze-card-editor")||customElements.define("autosnooze-card-editor",rt),customElements.get("autosnooze-card")||customElements.define("autosnooze-card",at),window.customCards=window.customCards||[],window.customCards.some(t=>"autosnooze-card"===t.type)||window.customCards.push({type:"autosnooze-card",name:"AutoSnooze Card",description:"Temporarily pause automations with area and label filtering (v2.9.23)",preview:!0});
+    `}getCardSize(){const t=this._getPaused(),e=this._getScheduled();return 4+Object.keys(t).length+Object.keys(e).length}setConfig(t){this.config=t}}customElements.get("autosnooze-card-editor")||customElements.define("autosnooze-card-editor",rt),customElements.get("autosnooze-card")||customElements.define("autosnooze-card",at),window.customCards=window.customCards||[],window.customCards.some(t=>"autosnooze-card"===t.type)||window.customCards.push({type:"autosnooze-card",name:"AutoSnooze Card",description:"Temporarily pause automations with area and label filtering (v2.9.26)",preview:!0});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autosnooze",
-  "version": "2.9.25",
+  "version": "2.9.26",
   "description": "AutoSnooze - Temporarily pause Home Assistant automations",
   "main": "custom_components/autosnooze/www/autosnooze-card.js",
   "scripts": {

--- a/src/autosnooze-card.js
+++ b/src/autosnooze-card.js
@@ -1,7 +1,7 @@
 import { LitElement, html, css } from "lit";
 
-// Version 2.9.25 - Fix service call datetime comparison with offset-naive datetimes
-const CARD_VERSION = "2.9.25";
+// Version 2.9.26 - Show start and end dates for schedule-mode snoozes
+const CARD_VERSION = "2.9.26";
 
 // ============================================================================
 // CARD EDITOR
@@ -1539,9 +1539,20 @@ class AutomationPauseCard extends LitElement {
                         <div class="paused-name">
                           ${data.friendly_name || id}
                         </div>
-                        <div class="paused-time">
-                          Waking up in: ${this._formatCountdown(data.resume_at)}
-                        </div>
+                        ${data.disable_at
+                          ? html`
+                              <div class="scheduled-time">
+                                Started: ${this._formatDateTime(data.disable_at)}
+                              </div>
+                              <div class="paused-time">
+                                Resumes: ${this._formatDateTime(data.resume_at)}
+                              </div>
+                            `
+                          : html`
+                              <div class="paused-time">
+                                Waking up in: ${this._formatCountdown(data.resume_at)}
+                              </div>
+                            `}
                       </div>
                       <button class="wake-btn" @click=${() => this._wake(id)}>
                         Wake Now


### PR DESCRIPTION
When an automation is snoozed via schedule mode, the active snooze box
now displays the original start and end dates instead of just a countdown.
This helps users see when a scheduled snooze started and when it will resume.

- Add disable_at field to PausedAutomation to track schedule mode origin
- Preserve disable_at when scheduled snoozes become active
- Update frontend to conditionally show dates or countdown based on mode
- Bump version to 2.9.26