### PR TITLE
Add native clear button to search input

### DIFF
--- a/custom_components/autosnooze/www/autosnooze-card.js
+++ b/custom_components/autosnooze/www/autosnooze-card.js
@@ -692,7 +692,7 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
           <!-- Search -->
           <div class="search-box">
             <input
-              type="text"
+              type="search"
               placeholder="Search automations..."
               .value=${this._search}
               @input=${t=>this._handleSearchInput(t)}
@@ -860,4 +860,4 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
               </div>
             `:""}
       </ha-card>
-    `}getCardSize(){const t=this._getPaused(),e=this._getScheduled();return 4+Object.keys(t).length+Object.keys(e).length}setConfig(t){this.config=t}}customElements.get("autosnooze-card-editor")||customElements.define("autosnooze-card-editor",rt),customElements.get("autosnooze-card")||customElements.define("autosnooze-card",at),window.customCards=window.customCards||[],window.customCards.some(t=>"autosnooze-card"===t.type)||window.customCards.push({type:"autosnooze-card",name:"AutoSnooze Card",description:"Temporarily pause automations with area and label filtering (v2.9.29)",preview:!0});
+    `}getCardSize(){const t=this._getPaused(),e=this._getScheduled();return 4+Object.keys(t).length+Object.keys(e).length}setConfig(t){this.config=t}}customElements.get("autosnooze-card-editor")||customElements.define("autosnooze-card-editor",rt),customElements.get("autosnooze-card")||customElements.define("autosnooze-card",at),window.customCards=window.customCards||[],window.customCards.some(t=>"autosnooze-card"===t.type)||window.customCards.push({type:"autosnooze-card",name:"AutoSnooze Card",description:"Temporarily pause automations with area and label filtering (v0.1.0)",preview:!0});

--- a/src/autosnooze-card.js
+++ b/src/autosnooze-card.js
@@ -1544,7 +1544,7 @@ class AutomationPauseCard extends LitElement {
           <!-- Search -->
           <div class="search-box">
             <input
-              type="text"
+              type="search"
               placeholder="Search automations..."
               .value=${this._search}
               @input=${(e) => this._handleSearchInput(e)}


### PR DESCRIPTION
## Summary
- Change search input from `type="text"` to `type="search"` to provide a native browser clear button (X icon)
- Makes it easier to clear the search field with a single click

## Test plan
- [ ] Verify the search bar shows an X icon when text is entered
- [ ] Verify clicking the X clears the search
- [ ] Verify search functionality still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)