### PR TITLE
Add HACS default repository requirements

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,33 @@
+name: Validate
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  validate-hacs:
+    name: HACS Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration
+
+  validate-hassfest:
+    name: Hassfest Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Hassfest validation
+        uses: home-assistant/actions/hassfest@master

--- a/custom_components/autosnooze/manifest.json
+++ b/custom_components/autosnooze/manifest.json
@@ -1,12 +1,13 @@
 {
   "domain": "autosnooze",
   "name": "AutoSnooze",
-  "codeowners": [],
+  "codeowners": ["@mossipcams"],
   "config_flow": true,
   "dependencies": ["frontend", "http", "lovelace"],
   "documentation": "https://github.com/mossipcams/autosnooze",
   "integration_type": "service",
   "iot_class": "local_push",
+  "issue_tracker": "https://github.com/mossipcams/autosnooze/issues",
   "requirements": [],
   "version": "0.1.0"
 }


### PR DESCRIPTION
## Summary
- Add `@mossipcams` as codeowner in manifest.json
- Add `issue_tracker` URL to manifest.json
- Create `validate.yml` workflow with HACS and Hassfest validation

These changes are required for submission to the HACS default repository.

## Test plan
- [ ] Verify HACS validation workflow passes
- [ ] Verify Hassfest validation workflow passes
- [ ] Verify existing build workflow still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)