### PR TITLE
Update Python test coverage threshold from 70% to 85%

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,5 +73,5 @@ exclude_lines = [
     "raise NotImplementedError",
     "if TYPE_CHECKING:",
 ]
-fail_under = 70
+fail_under = 85
 show_missing = true


### PR DESCRIPTION
Align Python coverage requirements with JavaScript thresholds
that were updated in commit dd6223b.