### PR TITLE
Update README images to use raw GitHub URLs for HACS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 **Temporarily pause Home Assistant automations with automatic re-enabling.**
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mossipcams/autosnooze/main/docs/images/card-main.jpeg" alt="AutoSnooze Card" width="400">
+  <img src="https://raw.githubusercontent.com/mossipcams/autosnooze/main/docs/images/card-main.jpg" alt="AutoSnooze Card" width="400">
   <img src="https://raw.githubusercontent.com/mossipcams/autosnooze/main/docs/images/card-snoozed.jpeg" alt="Snoozed Automations" width="400">
 </p>
 


### PR DESCRIPTION
Use raw.githubusercontent.com URLs so images display properly
when viewed through HACS instead of relative paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated image references in README from local paths to absolute GitHub raw URLs for consistent display across all platforms and external integrations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->