### PR TITLE
Skip CodeRabbit reviews on markdown files

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,6 +16,18 @@ reviews:
     - "!**/*.min.js"
     - "!**/package-lock.json"
     - "!**/*.md"
+    - "!LICENSE"
+    - "!.gitignore"
+    - "!hacs.json"
+    - "!**/*.png"
+    - "!**/*.jpg"
+    - "!**/*.svg"
+    - "!**/*.ico"
+    - "!**/*.gif"
+    - "!docs/**"
+    - "!.github/ISSUE_TEMPLATE/**"
+    - "!.github/dependabot.yml"
+    - "!.husky/**"
   path_instructions:
     - path: "custom_components/**/*.py"
       instructions: |


### PR DESCRIPTION
Add exclusion pattern for .md files to path_filters to prevent
unnecessary code reviews on documentation changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration to refine file filtering for code review processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->