### PR TITLE
Fix race conditions and improve robustness of HA integration

### DIFF
--- a/custom_components/autosnooze/sensor.py
+++ b/custom_components/autosnooze/sensor.py
@@ -27,6 +27,7 @@ class AutoSnoozeCountSensor(SensorEntity):
     _attr_has_entity_name = True
     _attr_translation_key = "snoozed_count"
     _attr_icon = "mdi:sleep"
+    _attr_should_poll = False  # Updates via listener, no polling needed
 
     def __init__(self, entry: AutomationPauseConfigEntry) -> None:
         """Initialize sensor."""


### PR DESCRIPTION
This commit addresses several critical and moderate issues identified
during code review that could cause Home Assistant instability:

Critical fixes:
- Add asyncio.Lock to prevent concurrent state modifications during
  service calls, which could cause race conditions and data corruption
- Add unloaded flag check in timer callbacks to prevent post-unload
  operations that could corrupt storage data
- Copy listeners list before iteration in notify() to prevent
  RuntimeError when listeners are modified during notification
- Store and cancel homeassistant_started listener to prevent stale
  data access if integration is unloaded before HA fully starts

Moderate fixes:
- Add data.notify() after async_load_stored to update UI with loaded state
- Add _attr_should_poll = False to sensor since it uses listener pattern
- Add try/except around manifest.json reading with fallback version
- Add early return for empty entity_ids list to avoid unnecessary I/O
- Make listener removal safe for double-unsubscribe calls
- Add better type annotations (Callable instead of Any)
- Add exception handling in notify() to prevent one bad listener from
  breaking all notifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown/startup reliability to prevent actions after unload and avoid post-unload errors.
  * Better concurrency handling to prevent race conditions during pause/resume and save operations.
  * Added retry/backoff for saves and more robust handling when extension metadata is unreadable.

* **New Features**
  * Sensor now updates via events (no polling).
  * Frontend asset URLs are version-aware for more reliable card loading.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->