### PR TITLE
Remove redundant pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,0 @@
-[pytest]
-testpaths = tests
-asyncio_mode = auto
-markers =
-    slow: marks tests as slow (deselect with '-m "not slow"')
-filterwarnings =
-    ignore::DeprecationWarning
-    ignore::pytest.PytestUnraisableExceptionWarning


### PR DESCRIPTION
pytest configuration is already defined in pyproject.toml under
[tool.pytest.ini_options]. Having both files causes confusion and
pytest reads pytest.ini first, ignoring the pyproject.toml settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration settings in pytest.ini.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->