### PR TITLE
feat: autofill current date/time when entering schedule mode

### DIFF
--- a/src/autosnooze-card.js
+++ b/src/autosnooze-card.js
@@ -1813,6 +1813,29 @@ class AutomationPauseCard extends LitElement {
     return `${date}T${time}${offsetStr}`;
   }
 
+  _getCurrentDateTime() {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const day = String(now.getDate()).padStart(2, "0");
+    const hours = String(now.getHours()).padStart(2, "0");
+    const minutes = String(now.getMinutes()).padStart(2, "0");
+
+    return {
+      date: `${year}-${month}-${day}`,
+      time: `${hours}:${minutes}`
+    };
+  }
+
+  _enterScheduleMode() {
+    const { date, time } = this._getCurrentDateTime();
+    this._scheduleMode = true;
+    this._disableAtDate = date;
+    this._disableAtTime = time;
+    this._resumeAtDate = date;
+    this._resumeAtTime = time;
+  }
+
   _getLocale() {
     // Use Home Assistant's locale setting, fallback to browser default
     return this.hass?.locale?.language || undefined;
@@ -2298,7 +2321,7 @@ class AutomationPauseCard extends LitElement {
             <button
               type="button"
               class="schedule-link"
-              @click=${() => (this._scheduleMode = true)}
+              @click=${() => this._enterScheduleMode()}
             >
               <ha-icon icon="mdi:calendar-clock" aria-hidden="true"></ha-icon>
               Pick specific date/time instead


### PR DESCRIPTION
## Summary
- When users click "Pick specific date/time instead" to enter schedule mode, both the "Snooze at" and "Resume at" fields are now pre-populated with the current date and time
- This provides a convenient starting point that users can adjust as needed

## Test plan
- [x] Lint passes (`npm run lint`)
- [x] All 197 tests pass (`npm test`)
- [ ] Manual test: Click "Pick specific date/time instead" and verify both date/time fields populate with current values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schedule mode to correctly initialize date and time fields with current values when activated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->