### PR TITLE
fix: add write permissions to version bump workflow

### DIFF
--- a/.github/workflows/release-version-bump.yml
+++ b/.github/workflows/release-version-bump.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   bump-version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `permissions: contents: write` to the release-version-bump workflow
- This fixes the 403 error when the workflow tries to push version bump commits to main

## Context
The v0.2.5 release triggered the version bump workflow, but it failed with:
```
remote: Permission to mossipcams/autosnooze.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/mossipcams/autosnooze/': The requested URL returned error: 403
```

## Test plan
- [ ] Merge this PR
- [ ] Re-run the failed workflow or create a new release to verify it can push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated GitHub Actions workflow permissions to enable the release process to properly modify repository contents when necessary.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->