### PR TITLE
fix: move release-please version annotation to same line

### DIFF
--- a/src/autosnooze-card.js
+++ b/src/autosnooze-card.js
@@ -1,7 +1,6 @@
 import { LitElement, html, css } from "lit";
 
-// x-release-please-version
-const CARD_VERSION = "0.2.5";
+const CARD_VERSION = "0.2.5"; // x-release-please-version
 
 // ============================================================================
 // CONSTANTS


### PR DESCRIPTION
The generic updater requires the x-release-please-version annotation
to be on the same line as the version value, not on a separate line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor internal code formatting adjustment with no impact on functionality or user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->