### PR TITLE
fix: restore original timer color to deep orange

### DIFF
--- a/custom_components/autosnooze/www/autosnooze-card.js
+++ b/custom_components/autosnooze/www/autosnooze-card.js
@@ -429,7 +429,7 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
       align-items: center;
       gap: 8px;
       padding: 8px 12px;
-      color: #ff9800;
+      color: #e65100;
       font-size: 0.85em;
       border-bottom: 1px solid var(--divider-color);
     }
@@ -467,7 +467,7 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
     }
     .countdown {
       font-size: 0.9em;
-      color: #ff9800;
+      color: #e65100;
       font-weight: 500;
       white-space: nowrap;
     }

--- a/src/autosnooze-card.js
+++ b/src/autosnooze-card.js
@@ -817,7 +817,7 @@ class AutomationPauseCard extends LitElement {
       align-items: center;
       gap: 8px;
       padding: 8px 12px;
-      color: #ff9800;
+      color: #e65100;
       font-size: 0.85em;
       border-bottom: 1px solid var(--divider-color);
     }
@@ -855,7 +855,7 @@ class AutomationPauseCard extends LitElement {
     }
     .countdown {
       font-size: 0.9em;
-      color: #ff9800;
+      color: #e65100;
       font-weight: 500;
       white-space: nowrap;
     }


### PR DESCRIPTION
## Summary
- Restores timer/countdown color from `#ff9800` (orange) back to `#e65100` (deep orange)
- This was the original color before the mobile UX changes

## Test plan
- [ ] Verify countdown timers display in deep orange (#e65100) color
- [ ] Verify pause group headers display in deep orange (#e65100) color

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated accent colors in the pause control interface and countdown display for enhanced visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->