### PR TITLE
fix: use secondary text color for countdown timers

### DIFF
--- a/custom_components/autosnooze/www/autosnooze-card.js
+++ b/custom_components/autosnooze/www/autosnooze-card.js
@@ -437,6 +437,7 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
       --mdc-icon-size: 18px;
     }
     .pause-group-header .countdown {
+      color: var(--secondary-text-color);
       font-weight: 600;
       font-variant-numeric: tabular-nums;
     }
@@ -467,7 +468,7 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
     }
     .countdown {
       font-size: 0.9em;
-      color: #e65100;
+      color: var(--secondary-text-color);
       font-weight: 500;
       white-space: nowrap;
     }
@@ -1201,6 +1202,7 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
       }
 
       .pause-group-header .countdown {
+        color: var(--secondary-text-color);
         font-size: 1em;
         font-weight: 700;
         font-variant-numeric: tabular-nums;

--- a/src/autosnooze-card.js
+++ b/src/autosnooze-card.js
@@ -825,6 +825,7 @@ class AutomationPauseCard extends LitElement {
       --mdc-icon-size: 18px;
     }
     .pause-group-header .countdown {
+      color: var(--secondary-text-color);
       font-weight: 600;
       font-variant-numeric: tabular-nums;
     }
@@ -855,7 +856,7 @@ class AutomationPauseCard extends LitElement {
     }
     .countdown {
       font-size: 0.9em;
-      color: #e65100;
+      color: var(--secondary-text-color);
       font-weight: 500;
       white-space: nowrap;
     }
@@ -1589,6 +1590,7 @@ class AutomationPauseCard extends LitElement {
       }
 
       .pause-group-header .countdown {
+        color: var(--secondary-text-color);
         font-size: 1em;
         font-weight: 700;
         font-variant-numeric: tabular-nums;


### PR DESCRIPTION
## Summary
- Changes countdown timer text from orange to `var(--secondary-text-color)`
- The snooze section borders/headers remain orange
- Timer text now uses the theme's secondary text color as originally intended

## Test plan
- [ ] Verify countdown timers use secondary text color (matches theme)
- [ ] Verify snooze section header/borders remain orange

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated countdown display styling to respect the app's secondary text color theme, improving visual consistency with the overall interface design.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->