### PR TITLE
fix: remove orange background from countdown timer

### DIFF
--- a/custom_components/autosnooze/www/autosnooze-card.js
+++ b/custom_components/autosnooze/www/autosnooze-card.js
@@ -1206,9 +1206,6 @@ const t=window,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"
         font-size: 1em;
         font-weight: 700;
         font-variant-numeric: tabular-nums;
-        padding: 3px 8px;
-        background: rgba(255, 152, 0, 0.15);
-        border-radius: 6px;
       }
 
       /* Paused items */

--- a/src/autosnooze-card.js
+++ b/src/autosnooze-card.js
@@ -1594,9 +1594,6 @@ class AutomationPauseCard extends LitElement {
         font-size: 1em;
         font-weight: 700;
         font-variant-numeric: tabular-nums;
-        padding: 3px 8px;
-        background: rgba(255, 152, 0, 0.15);
-        border-radius: 6px;
       }
 
       /* Paused items */


### PR DESCRIPTION
## Summary
- Removes the orange background pill from countdown timers on mobile
- Timer text uses secondary text color with no orange styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)