### PR TITLE
chore: suppress false positive semgrep format string warning

### DIFF
--- a/src/autosnooze-card.js
+++ b/src/autosnooze-card.js
@@ -336,6 +336,8 @@ class AutomationPauseCard extends LitElement {
       this[targetProp] = itemMap;
       this[fetchedFlag] = true;
     } catch (err) {
+      // nosemgrep: javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring
+      // logName is always a hardcoded string literal, not user input
       console.warn(`[AutoSnooze] Failed to fetch ${logName}:`, err);
     }
   }


### PR DESCRIPTION
## Summary
- Adds nosemgrep comment to suppress false positive `unsafe-formatstring` warning
- The `logName` parameter is always a hardcoded string literal ("label registry", "category registry", "entity registry"), never user input

## Test plan
- [x] Verify Semgrep no longer flags this line
- [x] ESLint passes
- [x] All JavaScript tests pass (545 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code annotations and quality improvements to enhance static analysis and code maintainability. No user-facing changes or behavioral modifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->