### PR TITLE
style: reduce card height on mobile

### DIFF
--- a/custom_components/autosnooze/www/autosnooze-card.js
+++ b/custom_components/autosnooze/www/autosnooze-card.js
@@ -765,11 +765,11 @@ const t=globalThis,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow
       }
 
       .tab {
-        padding: 10px 8px;
+        padding: 8px 6px;
         font-size: 0.82em;
         font-weight: 500;
         border-radius: 11px;
-        min-height: 44px;
+        min-height: 40px;
         flex: 1 1 0;
         justify-content: center;
         border: none;
@@ -871,7 +871,7 @@ const t=globalThis,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow
 
       /* --- Selection List: Card-style items with depth --- */
       .selection-list {
-        max-height: min(260px, 40dvh);
+        max-height: min(200px, 35dvh);
         margin-bottom: 16px;
         border-radius: 14px;
         border: 1.5px solid color-mix(in srgb, var(--divider-color) 60%, transparent);

--- a/src/autosnooze-card.js
+++ b/src/autosnooze-card.js
@@ -1155,11 +1155,11 @@ class AutomationPauseCard extends LitElement {
       }
 
       .tab {
-        padding: 10px 8px;
+        padding: 8px 6px;
         font-size: 0.82em;
         font-weight: 500;
         border-radius: 11px;
-        min-height: 44px;
+        min-height: 40px;
         flex: 1 1 0;
         justify-content: center;
         border: none;
@@ -1261,7 +1261,7 @@ class AutomationPauseCard extends LitElement {
 
       /* --- Selection List: Card-style items with depth --- */
       .selection-list {
-        max-height: min(260px, 40dvh);
+        max-height: min(200px, 35dvh);
         margin-bottom: 16px;
         border-radius: 14px;
         border: 1.5px solid color-mix(in srgb, var(--divider-color) 60%, transparent);


### PR DESCRIPTION
- Reduce tab padding and min-height for more compact filter tabs
- Shrink selection list max-height from 260px/40dvh to 200px/35dvh

Saves approximately 72px of vertical space on mobile screens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined tab control spacing and sizing for a more compact appearance.
  * Reduced selection list maximum height for improved layout density.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->