### PR TITLE
ci: enable HACS validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,7 +24,6 @@ permissions: {}
 jobs:
   validate-hacs:
     name: HACS Validation
-    if: false # Disabled - not currently used
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary
Enable HACS Action validation in the Validate workflow for HACS default repository submission.

## Changes
- Removed `if: false` from `validate-hacs` job in `.github/workflows/validate.yml`

## Context
This is required for submitting AutoSnooze to the [hacs/default](https://github.com/hacs/default) repository. The HACS Action must be enabled and passing before submission.

## Test plan
- [ ] HACS Validation job runs and passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled HACS validation in the continuous integration pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->