### PR TITLE
fix(i18n): add missing Button 4 translation for preset_4

### DIFF
--- a/custom_components/autosnooze/translations/en.json
+++ b/custom_components/autosnooze/translations/en.json
@@ -11,16 +11,18 @@
     "step": {
       "init": {
         "title": "Duration Buttons",
-        "description": "Set up to 3 quick-select duration buttons for the card. Leave empty to skip.",
+        "description": "Set up to 4 quick-select duration buttons for the card. Leave empty to skip.",
         "data": {
           "preset_1": "Button 1",
           "preset_2": "Button 2",
-          "preset_3": "Button 3"
+          "preset_3": "Button 3",
+          "preset_4": "Button 4"
         },
         "data_description": {
           "preset_1": "e.g., 30m, 1h, 2h30m, or 1d",
           "preset_2": "e.g., 30m, 1h, 2h30m, or 1d",
-          "preset_3": "e.g., 30m, 1h, 2h30m, or 1d"
+          "preset_3": "e.g., 30m, 1h, 2h30m, or 1d",
+          "preset_4": "e.g., 30m, 1h, 2h30m, or 1d"
         }
       }
     },


### PR DESCRIPTION
## Summary
- Added missing translation for the 4th preset button in integration settings
- Updated description to reflect "up to 4" buttons instead of "up to 3"

## Details
The config flow has supported 4 preset fields since the individual field configuration was introduced (`NUM_PRESET_FIELDS = 4` in `config_flow.py`), but the English translation file was missing the label and description for `preset_4`. This resulted in an unlabeled field in the integration settings UI.

### Changes
- Added `"preset_4": "Button 4"` label
- Added `"preset_4": "e.g., 30m, 1h, 2h30m, or 1d"` description
- Updated form description from "Set up to 3 quick-select duration buttons" to "Set up to 4 quick-select duration buttons"

## Test plan
- [x] Verified translation file structure is valid JSON
- [x] Confirmed all 4 preset fields now have matching labels and descriptions
- [ ] Manual test: Open integration settings and verify all 4 button fields are properly labeled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Auto-snooze feature now offers four quick-select duration preset buttons instead of three, providing additional scheduling flexibility for users to quickly set snooze intervals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->