### PR TITLE
ci: dispatch build for release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,6 +35,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
+      actions: write
     steps:
       - name: Parse release PR metadata
         id: pr
@@ -73,11 +74,16 @@ jobs:
         run: |
           if git diff --quiet -- custom_components/autosnooze/www/autosnooze-card.js custom_components/autosnooze/www/autosnooze-card.js.map; then
             echo "Generated artifact already up to date."
-            exit 0
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add custom_components/autosnooze/www/autosnooze-card.js custom_components/autosnooze/www/autosnooze-card.js.map
+            git commit -m "build: refresh generated card artifact for release PR"
+            git push origin "HEAD:$BRANCH_NAME"
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add custom_components/autosnooze/www/autosnooze-card.js custom_components/autosnooze/www/autosnooze-card.js.map
-          git commit -m "build: refresh generated card artifact for release PR"
-          git push origin "HEAD:$BRANCH_NAME"
+      - name: Dispatch required Build workflow for release PR
+        env:
+          BRANCH_NAME: ${{ steps.pr.outputs.branch }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run build.yml --ref "$BRANCH_NAME"

--- a/ci_contracts/test_release_pr_workflow.py
+++ b/ci_contracts/test_release_pr_workflow.py
@@ -35,3 +35,25 @@ def test_release_workflow_refreshes_generated_card_artifact_for_release_prs() ->
         "Release workflow must rebuild and push the generated card artifact for release PRs. "
         f"Missing snippets: {missing}"
     )
+
+
+def test_release_workflow_reports_required_build_check_for_bot_authored_release_prs() -> None:
+    """Release PRs created with GITHUB_TOKEN still need the required build check."""
+    assert RELEASE_WORKFLOW_PATH.exists(), "release-please workflow is missing"
+
+    content = RELEASE_WORKFLOW_PATH.read_text()
+
+    required_snippets = [
+        "actions: write",
+        "gh workflow run build.yml --ref \"$BRANCH_NAME\"",
+        "Generated artifact already up to date.",
+        "Dispatch required Build workflow for release PR",
+        "GH_TOKEN: ${{ github.token }}",
+    ]
+
+    missing = [snippet for snippet in required_snippets if snippet not in content]
+    assert not missing, (
+        "Release PR commits authored by github-actions[bot] do not automatically trigger pull_request "
+        "workflows, so release-please must explicitly dispatch build.yml for the release PR branch. "
+        f"Missing snippets: {missing}"
+    )


### PR DESCRIPTION
## Summary
- dispatch the required Build workflow after release-please refreshes release PR artifacts
- keep the dispatch in the no-diff case so bot-authored release PRs still report the required build check
- add a CI contract covering the release PR build dispatch behavior

## Verification
- python3 -m pytest ci_contracts/test_release_pr_workflow.py -q
- python3 -m pytest ci_contracts -q
- npm run lint:unused