### PR TITLE
ci: keep release PR branches current

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -87,3 +87,90 @@ jobs:
           BRANCH_NAME: ${{ steps.pr.outputs.branch }}
           GH_TOKEN: ${{ github.token }}
         run: gh workflow run build.yml --ref "$BRANCH_NAME"
+
+  sync-existing-release-pr:
+    needs: release-please
+    if: ${{ github.event_name == 'push' && needs.release-please.outputs.prs_created != 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: write
+    steps:
+      - name: Find existing Release Please PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pr_json="$(
+            gh pr list \
+              --state open \
+              --label "autorelease: pending" \
+              --json number,headRefName,author \
+              --jq '[.[] | select(.headRefName | startswith("release-please--branches--main--components--")) | select(.author.is_bot == true)] | first // {}'
+          )"
+
+          pr_number="$(printf '%s' "$pr_json" | jq -r '.number // empty')"
+          branch_name="$(printf '%s' "$pr_json" | jq -r '.headRefName // empty')"
+
+          if [ -z "$pr_number" ] || [ -z "$branch_name" ]; then
+            echo "No open Release Please PR found."
+            echo "number=" >> "$GITHUB_OUTPUT"
+            echo "branch=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch_name" >> "$GITHUB_OUTPUT"
+
+      - name: Update Release Please PR branch from main
+        if: ${{ steps.pr.outputs.number != '' && startsWith(steps.pr.outputs.branch, 'release-please--branches--main--components--') }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: gh pr update-branch "$PR_NUMBER"
+
+      - name: Checkout synced release PR branch
+        if: ${{ steps.pr.outputs.branch != '' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.pr.outputs.branch }}
+
+      - name: Setup Node.js for synced release PR
+        if: ${{ steps.pr.outputs.branch != '' }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20.19.0'
+          cache: 'npm'
+
+      - name: Install npm dependencies for synced release PR
+        if: ${{ steps.pr.outputs.branch != '' }}
+        run: npm ci
+
+      - name: Rebuild synced generated card artifact
+        if: ${{ steps.pr.outputs.branch != '' }}
+        run: npm run build
+
+      - name: Commit synced generated card artifact
+        if: ${{ steps.pr.outputs.branch != '' }}
+        env:
+          BRANCH_NAME: ${{ steps.pr.outputs.branch }}
+        run: |
+          if git diff --quiet -- custom_components/autosnooze/www/autosnooze-card.js custom_components/autosnooze/www/autosnooze-card.js.map; then
+            echo "Synced generated artifact already up to date."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add custom_components/autosnooze/www/autosnooze-card.js custom_components/autosnooze/www/autosnooze-card.js.map
+            git commit -m "build: refresh generated card artifact for synced release PR"
+            git push origin "HEAD:$BRANCH_NAME"
+          fi
+
+      - name: Dispatch required Build workflow for synced release PR
+        if: ${{ steps.pr.outputs.branch != '' }}
+        env:
+          BRANCH_NAME: ${{ steps.pr.outputs.branch }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run build.yml --ref "$BRANCH_NAME"

--- a/ci_contracts/test_release_pr_workflow.py
+++ b/ci_contracts/test_release_pr_workflow.py
@@ -57,3 +57,50 @@ def test_release_workflow_reports_required_build_check_for_bot_authored_release_
         "workflows, so release-please must explicitly dispatch build.yml for the release PR branch. "
         f"Missing snippets: {missing}"
     )
+
+
+def test_release_workflow_syncs_existing_release_pr_after_main_updates() -> None:
+    """An already-open release PR must be kept current when later PRs merge."""
+    assert RELEASE_WORKFLOW_PATH.exists(), "release-please workflow is missing"
+
+    content = RELEASE_WORKFLOW_PATH.read_text()
+
+    required_snippets = [
+        "sync-existing-release-pr",
+        "github.event_name == 'push'",
+        "autorelease: pending",
+        "gh pr list",
+        "startsWith(steps.pr.outputs.branch, 'release-please--branches--main--components--')",
+        "gh pr update-branch \"$PR_NUMBER\"",
+        "gh workflow run build.yml --ref \"$BRANCH_NAME\"",
+    ]
+
+    missing = [snippet for snippet in required_snippets if snippet not in content]
+    assert not missing, (
+        "Release Please can leave an existing release PR branch stale when new non-release-note PRs "
+        "merge into main. The release workflow must find the open Release Please PR, update its "
+        "branch from main, and dispatch the required build check. "
+        f"Missing snippets: {missing}"
+    )
+
+
+def test_synced_release_pr_refreshes_generated_artifact_after_branch_update() -> None:
+    """A synced release PR must rebuild artifacts after pulling in newer main code."""
+    assert RELEASE_WORKFLOW_PATH.exists(), "release-please workflow is missing"
+
+    content = RELEASE_WORKFLOW_PATH.read_text()
+
+    required_snippets = [
+        "Checkout synced release PR branch",
+        "Rebuild synced generated card artifact",
+        "Commit synced generated card artifact",
+        "Synced generated artifact already up to date.",
+        "custom_components/autosnooze/www/autosnooze-card.js.map",
+    ]
+
+    missing = [snippet for snippet in required_snippets if snippet not in content]
+    assert not missing, (
+        "When a stale release PR branch is updated from main, generated frontend artifacts must be "
+        "rebuilt on that updated branch before the required build check is dispatched. "
+        f"Missing snippets: {missing}"
+    )


### PR DESCRIPTION
## Summary
- sync existing open Release Please PR branches after main updates when Release Please does not rewrite release files
- rebuild and commit generated card artifacts after syncing a stale release PR branch
- add CI contracts for stale release PR branch and artifact refresh behavior

## Verification
- rtk python3 -m pytest ci_contracts/test_release_pr_workflow.py -q
- rtk python3 -m pytest ci_contracts -q
- rtk npm run lint:unused
- rtk docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.4 -color