### PR TITLE
ci: pass repo to release PR sync calls

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -105,6 +105,7 @@ jobs:
         run: |
           pr_json="$(
             gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
               --state open \
               --label "autorelease: pending" \
               --json number,headRefName,author \
@@ -129,7 +130,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-        run: gh pr update-branch "$PR_NUMBER"
+        run: gh pr update-branch "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"
 
       - name: Checkout synced release PR branch
         if: ${{ steps.pr.outputs.branch != '' }}

--- a/ci_contracts/test_release_pr_workflow.py
+++ b/ci_contracts/test_release_pr_workflow.py
@@ -104,3 +104,23 @@ def test_synced_release_pr_refreshes_generated_artifact_after_branch_update() ->
         "rebuilt on that updated branch before the required build check is dispatched. "
         f"Missing snippets: {missing}"
     )
+
+
+def test_release_workflow_passes_repo_to_gh_before_checkout() -> None:
+    """GitHub CLI calls before checkout cannot rely on local repository discovery."""
+    assert RELEASE_WORKFLOW_PATH.exists(), "release-please workflow is missing"
+
+    content = RELEASE_WORKFLOW_PATH.read_text()
+
+    required_snippets = [
+        "--repo \"$GITHUB_REPOSITORY\"",
+        "gh pr list \\",
+        "gh pr update-branch \"$PR_NUMBER\" --repo \"$GITHUB_REPOSITORY\"",
+    ]
+
+    missing = [snippet for snippet in required_snippets if snippet not in content]
+    assert not missing, (
+        "Release workflow jobs that run gh before actions/checkout must pass the repository "
+        "explicitly, otherwise gh fails with 'not a git repository'. "
+        f"Missing snippets: {missing}"
+    )


### PR DESCRIPTION
## Summary
- pass the repository explicitly to gh calls that run before checkout in the release PR sync job
- add a CI contract for pre-checkout gh repo discovery failures

## Verification
- rtk python3 -m pytest ci_contracts/test_release_pr_workflow.py -q
- rtk python3 -m pytest ci_contracts -q
- rtk npm run lint:unused
- rtk docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.4 -color