### PR TITLE
ci: mirror release PR build status

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,6 +36,8 @@ jobs:
     permissions:
       contents: write
       actions: write
+      checks: write
+      statuses: write
     steps:
       - name: Parse release PR metadata
         id: pr
@@ -69,6 +71,7 @@ jobs:
         run: npm run build
 
       - name: Commit refreshed generated card artifact
+        id: artifact
         env:
           BRANCH_NAME: ${{ steps.pr.outputs.branch }}
         run: |
@@ -81,12 +84,86 @@ jobs:
             git commit -m "build: refresh generated card artifact for release PR"
             git push origin "HEAD:$BRANCH_NAME"
           fi
+          echo "head-sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Dispatch required Build workflow for release PR
+      - name: Dispatch required Build workflow for release PR and mirror result
         env:
           BRANCH_NAME: ${{ steps.pr.outputs.branch }}
+          HEAD_SHA: ${{ steps.artifact.outputs.head-sha }}
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run build.yml --ref "$BRANCH_NAME"
+        run: |
+          started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          gh workflow run build.yml --ref "$BRANCH_NAME"
+
+          RUN_ID=""
+          for ((attempt = 1; attempt <= 30; attempt++)); do
+            RUN_ID="$(
+              gh run list \
+                --workflow build.yml \
+                --branch "$BRANCH_NAME" \
+                --event workflow_dispatch \
+                --json databaseId,createdAt,headSha \
+                --jq '[.[] | select(.headSha == "'"$HEAD_SHA"'" and .createdAt >= "'"$started_at"'")] | sort_by(.createdAt) | last | .databaseId // empty'
+            )"
+
+            if [ -n "$RUN_ID" ]; then
+              break
+            fi
+
+            sleep 5
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "Unable to find dispatched Build workflow run for $BRANCH_NAME at $HEAD_SHA."
+            exit 1
+          fi
+
+          set +e
+          gh run watch "$RUN_ID" --exit-status --interval 10
+          watch_status=$?
+          set -e
+
+          run_json="$(gh run view "$RUN_ID" --json conclusion,url)"
+          conclusion="$(printf '%s' "$run_json" | jq -r '.conclusion // empty')"
+          target_url="$(printf '%s' "$run_json" | jq -r '.url // empty')"
+
+          case "$conclusion" in
+            success)
+              status_state="success"
+              check_conclusion="success"
+              ;;
+            cancelled|timed_out|action_required|neutral|skipped)
+              status_state="failure"
+              check_conclusion="$conclusion"
+              ;;
+            *)
+              status_state="failure"
+              check_conclusion="failure"
+              ;;
+          esac
+
+          gh api \
+            -X POST \
+            "repos/${GITHUB_REPOSITORY}/check-runs" \
+            -f name="build" \
+            -f head_sha="$HEAD_SHA" \
+            -f status="completed" \
+            -f conclusion="$check_conclusion" \
+            -f details_url="$target_url" \
+            -f "output[title]=Build workflow $conclusion" \
+            -f "output[summary]=Mirrored from workflow_dispatch run $RUN_ID."
+
+          gh api \
+            -X POST \
+            "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f state="$status_state" \
+            -f context="build" \
+            -f target_url="$target_url" \
+            -f description="Build workflow $conclusion"
+
+          if [ "$watch_status" -ne 0 ] || [ "$status_state" != "success" ]; then
+            exit 1
+          fi
 
   sync-existing-release-pr:
     needs: release-please
@@ -97,6 +174,8 @@ jobs:
       contents: write
       pull-requests: write
       actions: write
+      checks: write
+      statuses: write
     steps:
       - name: Find existing Release Please PR
         id: pr
@@ -155,6 +234,7 @@ jobs:
         run: npm run build
 
       - name: Commit synced generated card artifact
+        id: synced-artifact
         if: ${{ steps.pr.outputs.branch != '' }}
         env:
           BRANCH_NAME: ${{ steps.pr.outputs.branch }}
@@ -168,10 +248,84 @@ jobs:
             git commit -m "build: refresh generated card artifact for synced release PR"
             git push origin "HEAD:$BRANCH_NAME"
           fi
+          echo "head-sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Dispatch required Build workflow for synced release PR
+      - name: Dispatch required Build workflow for synced release PR and mirror result
         if: ${{ steps.pr.outputs.branch != '' }}
         env:
           BRANCH_NAME: ${{ steps.pr.outputs.branch }}
+          HEAD_SHA: ${{ steps.synced-artifact.outputs.head-sha }}
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run build.yml --ref "$BRANCH_NAME"
+        run: |
+          started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          gh workflow run build.yml --ref "$BRANCH_NAME"
+
+          RUN_ID=""
+          for ((attempt = 1; attempt <= 30; attempt++)); do
+            RUN_ID="$(
+              gh run list \
+                --workflow build.yml \
+                --branch "$BRANCH_NAME" \
+                --event workflow_dispatch \
+                --json databaseId,createdAt,headSha \
+                --jq '[.[] | select(.headSha == "'"$HEAD_SHA"'" and .createdAt >= "'"$started_at"'")] | sort_by(.createdAt) | last | .databaseId // empty'
+            )"
+
+            if [ -n "$RUN_ID" ]; then
+              break
+            fi
+
+            sleep 5
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "Unable to find dispatched Build workflow run for $BRANCH_NAME at $HEAD_SHA."
+            exit 1
+          fi
+
+          set +e
+          gh run watch "$RUN_ID" --exit-status --interval 10
+          watch_status=$?
+          set -e
+
+          run_json="$(gh run view "$RUN_ID" --json conclusion,url)"
+          conclusion="$(printf '%s' "$run_json" | jq -r '.conclusion // empty')"
+          target_url="$(printf '%s' "$run_json" | jq -r '.url // empty')"
+
+          case "$conclusion" in
+            success)
+              status_state="success"
+              check_conclusion="success"
+              ;;
+            cancelled|timed_out|action_required|neutral|skipped)
+              status_state="failure"
+              check_conclusion="$conclusion"
+              ;;
+            *)
+              status_state="failure"
+              check_conclusion="failure"
+              ;;
+          esac
+
+          gh api \
+            -X POST \
+            "repos/${GITHUB_REPOSITORY}/check-runs" \
+            -f name="build" \
+            -f head_sha="$HEAD_SHA" \
+            -f status="completed" \
+            -f conclusion="$check_conclusion" \
+            -f details_url="$target_url" \
+            -f "output[title]=Build workflow $conclusion" \
+            -f "output[summary]=Mirrored from workflow_dispatch run $RUN_ID."
+
+          gh api \
+            -X POST \
+            "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f state="$status_state" \
+            -f context="build" \
+            -f target_url="$target_url" \
+            -f description="Build workflow $conclusion"
+
+          if [ "$watch_status" -ne 0 ] || [ "$status_state" != "success" ]; then
+            exit 1
+          fi

--- a/ci_contracts/test_release_pr_workflow.py
+++ b/ci_contracts/test_release_pr_workflow.py
@@ -124,3 +124,28 @@ def test_release_workflow_passes_repo_to_gh_before_checkout() -> None:
         "explicitly, otherwise gh fails with 'not a git repository'. "
         f"Missing snippets: {missing}"
     )
+
+
+def test_release_workflow_mirrors_dispatched_build_to_release_pr_head() -> None:
+    """Dispatched builds must report a required build check on bot-authored PR heads."""
+    assert RELEASE_WORKFLOW_PATH.exists(), "release-please workflow is missing"
+
+    content = RELEASE_WORKFLOW_PATH.read_text()
+
+    required_snippets = [
+        "checks: write",
+        "statuses: write",
+        "gh run watch \"$RUN_ID\" --exit-status",
+        "repos/${GITHUB_REPOSITORY}/check-runs",
+        "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}",
+        "-f name=\"build\"",
+        "-f context=\"build\"",
+    ]
+
+    missing = [snippet for snippet in required_snippets if snippet not in content]
+    assert not missing, (
+        "Workflow-dispatched builds are not reliably attached to bot-authored Release Please PR "
+        "heads. The release workflow must wait for the dispatched build and mirror its result as "
+        "an explicit required build check/status on the release PR head SHA. "
+        f"Missing snippets: {missing}"
+    )


### PR DESCRIPTION
## Summary
- wait for dispatched release PR Build workflows to finish
- mirror the result as an explicit build check run and commit status on the release PR head
- add a CI contract covering workflow-dispatch build status mirroring

## Verification
- rtk python3 -m pytest ci_contracts/test_release_pr_workflow.py -q
- rtk python3 -m pytest ci_contracts -q
- rtk npm run lint:unused
- rtk docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.4 -color