### PR TITLE
chore(deps): update Home Assistant test fixture

### DIFF
--- a/ci_contracts/test_python_dependencies_contract.py
+++ b/ci_contracts/test_python_dependencies_contract.py
@@ -14,7 +14,7 @@ def test_pytest_homeassistant_custom_component_tracks_homeassistant_2026_5_beta(
     """Keep HA test fixtures aligned with the Dependabot PR #370 update."""
     requirements = REQUIREMENTS_TEST_PATH.read_text(encoding="utf-8")
 
-    assert "pytest-homeassistant-custom-component>=0.13.326,<0.13.327" in requirements
+    assert "pytest-homeassistant-custom-component>=0.13.330,<0.13.331" in requirements
 
 
 def test_pytest_matches_homeassistant_2026_5_fixture_dependency() -> None:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,7 +3,7 @@
 
 pytest==9.0.3
 pytest-asyncio==1.3.0
-pytest-homeassistant-custom-component>=0.13.326,<0.13.327
+pytest-homeassistant-custom-component>=0.13.330,<0.13.331
 pytest-cov==7.1.0
 
 # Linting and formatting (ruff handles both)


### PR DESCRIPTION
## Summary
- carry forward Dependabot's pytest-homeassistant-custom-component update from #379
- update the Python dependency CI contract to expect the new 0.13.330 range

Supersedes #379.

## Verification
- pytest ci_contracts/test_python_dependencies_contract.py -q
- pytest ci_contracts -q
- ruff check ci_contracts/test_python_dependencies_contract.py
- ruff format --check --diff ci_contracts/test_python_dependencies_contract.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `pytest-homeassistant-custom-component` test dependency to version 0.13.330 or higher.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mossipcams/autosnooze/pull/384)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->