### PR TITLE
test: harden architecture and mutation coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ reports/
 # Stryker mutation testing
 .stryker-tmp/
 stryker-result.txt
+mutants/
 
 # Linter caches
 .eslintcache

--- a/architecture.md
+++ b/architecture.md
@@ -1,14 +1,12 @@
 # AutoSnooze Architecture
 
-AutoSnooze is a modular monolith. The integration ships as one Home Assistant custom component and one bundled Lovelace card, but implementation should stay organized around small slices with clear dependency direction.
+AutoSnooze is a modular monolith. Code should stay in a small number of explicit layers, with feature slices owning orchestration and components/services staying thin enough to reason about.
 
-## Frontend Layers
+## Frontend layer direction
 
 Preferred dependency flow:
 
-```text
-src/components -> src/features -> src/services | src/state | src/utils | src/constants | src/types
-```
+`components -> features -> services/state -> utils/constants/types`
 
 Components own rendering, events, and local UI state. They should not import runtime services or shared state helpers directly. When a component needs orchestration or runtime data, expose that through a feature slice facade.
 
@@ -20,20 +18,19 @@ State helpers own framework-agnostic snapshots, stores, and derived state. State
 
 Utilities, constants, and types sit at the bottom. They may be imported broadly but should not import higher layers.
 
-## Backend Layers
+## Backend layer direction
 
 Preferred dependency flow:
 
-```text
-services.py -> application -> runtime | infrastructure | models | const | logging_utils
-sensor.py -> runtime | models | const
-```
+`services -> application -> runtime/infrastructure/domain/models`
 
 `services.py` is the Home Assistant service registration adapter. It should validate service calls and delegate orchestration to application modules.
 
 Application modules own workflows such as pause, resume, adjust, schedule, and setup. They must not import `services.py`; that would couple orchestration back to the registration layer.
 
 Runtime modules own restore, timers, and in-memory runtime helpers. Infrastructure modules own storage and other external persistence concerns. Models define serializable domain data and should remain low-level.
+
+No upward imports: lower layers must not import higher-level orchestration modules to complete a workflow. If a lower layer needs behavior from a higher layer, pass a callable into it from the higher layer instead of importing upward.
 
 ## Enforcement
 

--- a/ci_contracts/test_architecture_document_contract.py
+++ b/ci_contracts/test_architecture_document_contract.py
@@ -1,0 +1,23 @@
+"""Contract tests for the architecture source-of-truth document."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+ARCHITECTURE_PATH = PROJECT_ROOT / "architecture.md"
+
+
+def test_architecture_document_exists_and_defines_layer_direction() -> None:
+    """AGENTS.md points at architecture.md, so the file must exist and be specific."""
+    assert ARCHITECTURE_PATH.exists(), "architecture.md must exist as the module-boundary source of truth"
+
+    source = ARCHITECTURE_PATH.read_text(encoding="utf-8")
+
+    assert "modular monolith" in source
+    assert "Frontend layer direction" in source
+    assert "components -> features -> services/state -> utils/constants/types" in source
+    assert "Backend layer direction" in source
+    assert "services -> application -> runtime/infrastructure/domain/models" in source
+    assert "No upward imports" in source

--- a/ci_contracts/test_backend_architecture_contract.py
+++ b/ci_contracts/test_backend_architecture_contract.py
@@ -1,0 +1,41 @@
+"""Contract tests for backend layer dependency direction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+BACKEND_ROOT = PROJECT_ROOT / "custom_components" / "autosnooze"
+
+
+def _source_files(*parts: str) -> list[Path]:
+    root = BACKEND_ROOT.joinpath(*parts)
+    return sorted(root.rglob("*.py"))
+
+
+def test_application_layer_has_no_upward_imports() -> None:
+    """Application use cases must not import service registration or coordinator modules."""
+    upward_import = re.compile(r"from\s+\.\.\s+import\s+(?:services|coordinator)|from\s+\.\.(?:services|coordinator)\s+import")
+
+    offenders = [
+        str(path.relative_to(PROJECT_ROOT))
+        for path in _source_files("application")
+        if upward_import.search(path.read_text(encoding="utf-8"))
+    ]
+
+    assert offenders == []
+
+
+def test_runtime_layer_has_no_upward_imports() -> None:
+    """Runtime helpers must receive callbacks instead of importing coordinator orchestration."""
+    upward_import = re.compile(r"from\s+\.\.coordinator\s+import")
+
+    offenders = [
+        str(path.relative_to(PROJECT_ROOT))
+        for path in _source_files("runtime")
+        if upward_import.search(path.read_text(encoding="utf-8"))
+    ]
+
+    assert offenders == []

--- a/ci_contracts/test_backend_mutation_runner_contract.py
+++ b/ci_contracts/test_backend_mutation_runner_contract.py
@@ -1,0 +1,55 @@
+"""Contracts for the backend mutation runner."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+RUNNER_PATH = PROJECT_ROOT / "scripts" / "run_backend_mutation.py"
+PACKAGE_JSON_PATH = PROJECT_ROOT / "package.json"
+
+
+def _runner_source() -> str:
+    assert RUNNER_PATH.exists(), "backend mutation runner script is missing"
+    return RUNNER_PATH.read_text(encoding="utf-8")
+
+
+def test_backend_mutation_runner_exists_and_avoids_forked_pytest_children() -> None:
+    source = _runner_source()
+    tree = ast.parse(source)
+
+    assert "os.fork" not in source
+    assert "MUTANT_UNDER_TEST" in source
+    assert any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "subprocess"
+        and any(alias.name == "run" for alias in node.names)
+        for node in ast.walk(tree)
+    ), "runner should execute mutant pytest runs in normal subprocesses"
+
+
+def test_backend_mutation_runner_exposes_expected_statuses() -> None:
+    source = _runner_source()
+
+    for status in ("killed", "survived", "no tests", "timeout", "crashed"):
+        assert status in source
+
+
+def test_backend_mutation_runner_knows_home_assistant_pytest_and_source_test_exclusion() -> None:
+    source = _runner_source()
+
+    assert "venv_test" in source
+    assert "TestLovelaceResourceSafety" in source
+    assert "PYTHONPATH" in source
+
+
+def test_package_json_exposes_backend_mutation_script() -> None:
+    package_json = json.loads(PACKAGE_JSON_PATH.read_text(encoding="utf-8"))
+
+    assert (
+        package_json["scripts"].get("mutation:backend")
+        == "python3 scripts/run_backend_mutation.py"
+    )

--- a/ci_contracts/test_jscpd_contract.py
+++ b/ci_contracts/test_jscpd_contract.py
@@ -8,8 +8,10 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 PACKAGE_JSON_PATH = PROJECT_ROOT / "package.json"
+PACKAGE_LOCK_PATH = PROJECT_ROOT / "package-lock.json"
 BUILD_WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "build.yml"
 JSCPD_CONFIG_PATH = PROJECT_ROOT / ".jscpd.json"
+EXPECTED_JSCPD_VERSION = "4.2.0"
 
 
 def test_package_json_exposes_blocking_jscpd_script() -> None:
@@ -24,6 +26,16 @@ def test_package_json_exposes_blocking_jscpd_script() -> None:
     assert "jscpd" in scripts["lint:duplicates"], "lint:duplicates must run jscpd"
     assert ".jscpd.json" in scripts["lint:duplicates"], "lint:duplicates must use the repo jscpd config"
     assert "jscpd" in dev_dependencies, "package.json must declare jscpd as a dev dependency"
+
+
+def test_jscpd_dependency_is_pinned_to_latest_supported_major() -> None:
+    """The duplication checker should stay on the vetted latest release."""
+    package_data = json.loads(PACKAGE_JSON_PATH.read_text())
+    lock_data = json.loads(PACKAGE_LOCK_PATH.read_text())
+
+    assert package_data["devDependencies"]["jscpd"] == f"^{EXPECTED_JSCPD_VERSION}"
+    assert lock_data["packages"][""]["devDependencies"]["jscpd"] == f"^{EXPECTED_JSCPD_VERSION}"
+    assert lock_data["packages"]["node_modules/jscpd"]["version"] == EXPECTED_JSCPD_VERSION
 
 
 def test_jscpd_config_targets_runtime_duplication_with_stricter_signal() -> None:

--- a/custom_components/autosnooze/infrastructure/storage.py
+++ b/custom_components/autosnooze/infrastructure/storage.py
@@ -26,29 +26,32 @@ async def async_save(
         "scheduled": data.get_scheduled_dict(),
     }
 
-    last_error = None
-    for attempt in range(MAX_SAVE_RETRIES + 1):
+    for attempt, delay in enumerate(SAVE_RETRY_DELAYS, start=1):
         try:
             await data.store.async_save(save_data)
             return True
         except TRANSIENT_ERRORS as err:
-            last_error = err
-            if attempt < MAX_SAVE_RETRIES:
-                delay = SAVE_RETRY_DELAYS[attempt]
-                _LOGGER.warning(
-                    "Save attempt %d failed, retrying in %.1fs: %s",
-                    attempt + 1,
-                    delay,
-                    err,
-                )
-                await sleep(delay)
+            _LOGGER.warning(
+                "Save attempt %d failed, retrying in %.1fs: %s",
+                attempt,
+                delay,
+                err,
+            )
+            await sleep(delay)
         except Exception as err:
             _LOGGER.error("Failed to save data: %s", err)
             return False
 
-    _LOGGER.error(
-        "Failed to save data after %d attempts: %s",
-        MAX_SAVE_RETRIES + 1,
-        last_error,
-    )
-    return False
+    try:
+        await data.store.async_save(save_data)
+        return True
+    except TRANSIENT_ERRORS as err:
+        _LOGGER.error(
+            "Failed to save data after %d attempts: %s",
+            MAX_SAVE_RETRIES + 1,
+            err,
+        )
+        return False
+    except Exception as err:
+        _LOGGER.error("Failed to save data: %s", err)
+        return False

--- a/knip.json
+++ b/knip.json
@@ -15,6 +15,9 @@
     "src/types/**/*.ts": [
       "types"
     ],
+    "src/components/autosnooze-actions-controller.ts": [
+      "exports"
+    ],
     "e2e/helpers/**/*.ts": [
       "exports",
       "types"
@@ -24,6 +27,9 @@
       "types"
     ]
   },
+  "ignoreBinaries": [
+    "python3"
+  ],
   "node": false,
   "treatConfigHintsAsErrors": true
 }

--- a/knip.production.json
+++ b/knip.production.json
@@ -15,6 +15,9 @@
   "ignoreDependencies": [
     "lit"
   ],
+  "ignoreBinaries": [
+    "python3"
+  ],
   "node": false,
   "treatConfigHintsAsErrors": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.2.19",
       "license": "MIT",
       "dependencies": {
-        "@oxc-parser/binding-linux-x64-gnu": "0.130.0",
         "lit": "^3.3.2"
       },
       "devDependencies": {
@@ -32,7 +31,7 @@
         "eslint": "^10.3.0",
         "globals": "^17.6.0",
         "husky": "^9.0.0",
-        "jscpd": "^4.1.0",
+        "jscpd": "^4.2.0",
         "jsdom": "^29.1.1",
         "knip": "^6.12.2",
         "lint-staged": "^17.0.4",
@@ -2018,9 +2017,9 @@
       }
     },
     "node_modules/@jscpd/badge-reporter": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@jscpd/badge-reporter/-/badge-reporter-4.1.0.tgz",
-      "integrity": "sha512-18dLePKrcUGP25MnwAWW2pCv9k6jYQI/AmtEroF7h/gvxJ7IakFKYIzDO8MO/HcFwfFDzkKe3AP2ZSrgUvN84w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@jscpd/badge-reporter/-/badge-reporter-4.2.0.tgz",
+      "integrity": "sha512-edvLAhMBsIo4OLsRTZNO6Mwm4rwJCiWYBiWc4qQdo6ZNFbJ6Sp3ZU9ceyEFMxFVBH2hwX94rHWzO4FgO4Rg4OQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2030,9 +2029,9 @@
       }
     },
     "node_modules/@jscpd/core": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@jscpd/core/-/core-4.1.0.tgz",
-      "integrity": "sha512-6hnibDeLfIWS5Dfy1V/CUf2CijszSe1Z2dNymfqwGK1BDqGaaXqXU3WMZzL0Us131rGLIqqExjfQrBGDQ940TA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@jscpd/core/-/core-4.2.0.tgz",
+      "integrity": "sha512-fkmjSlTqGQ/PMpAHJqYl5qqB4ALmfj/3i6urfTfme1SR1zLUVgyUQV8KmRQdP2JLn4ZUg16DnuZ4Qgug/8LOew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2040,14 +2039,14 @@
       }
     },
     "node_modules/@jscpd/finder": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@jscpd/finder/-/finder-4.1.0.tgz",
-      "integrity": "sha512-7bb6Ap+/BGmmZjopq6LZ7knXl2BW3uYvfRMg5eZ44KMzQBUZTAF154SdQMkFBA4tPZKOtMf1SjOJI55ja+2CFQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@jscpd/finder/-/finder-4.2.0.tgz",
+      "integrity": "sha512-5A53+csbgRqvBBWFY53ZG44CVMEmxE4jmBW4Y7fH1qR7w/Wb+PYOSn0R69+yfNv6vTL9m2VPdGHUQu9o/ggpNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jscpd/core": "4.1.0",
-        "@jscpd/tokenizer": "4.1.0",
+        "@jscpd/core": "4.2.0",
+        "@jscpd/tokenizer": "4.2.0",
         "blamer": "^1.0.6",
         "bytes": "^3.1.2",
         "cli-table3": "^0.6.5",
@@ -2059,9 +2058,9 @@
       }
     },
     "node_modules/@jscpd/html-reporter": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@jscpd/html-reporter/-/html-reporter-4.1.0.tgz",
-      "integrity": "sha512-mINEEgtgITHGpF9U9vL/caf48msNarBeDJCBRA6S7xnHkIoDjjYNxeEyJSI7sAlcGeibl21sHOtfjpJz8i2tRQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@jscpd/html-reporter/-/html-reporter-4.2.0.tgz",
+      "integrity": "sha512-JkMloHiW0bsurnfOiVNJHqJ728Dk2q+yoVuPaTp1XFMvvH6cRXUcOr331B7QR9S9H5OAgeB322qJ/xOEU3rAcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2071,14 +2070,14 @@
       }
     },
     "node_modules/@jscpd/tokenizer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@jscpd/tokenizer/-/tokenizer-4.1.0.tgz",
-      "integrity": "sha512-eYQun9bMOcSj14C7uH3QDkkQqIogRem+UqFYLuyt6UqJ+PrXJJkoa+gRTICqyY/xH73HsXy0BPNhGMsi3wTMGg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@jscpd/tokenizer/-/tokenizer-4.2.0.tgz",
+      "integrity": "sha512-jywXhLyzSzP+g/Qfe9IlZk3kPYdy7WKSFXSqgCszIrbR8EjbBrQZ6fyO683So3sWKyFAIpuvYUtnqpNTIefStw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jscpd/core": "4.1.0",
-        "prismjs": "^1.30.0"
+        "@jscpd/core": "4.2.0",
+        "spark-md5": "^3.0.2"
       }
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
@@ -6633,30 +6632,30 @@
       "license": "MIT"
     },
     "node_modules/jscpd": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-4.1.0.tgz",
-      "integrity": "sha512-LOXYBLp08+CoCVmb161k4rdR7Za/IGilmKnhXb9uLSgGSq135JMEXRku71xWpCDRyNzZHltxYbYgd8gkrdqJ2Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-4.2.0.tgz",
+      "integrity": "sha512-C0J/Tggbt5bKnJK/izPGR8aIdfEgzyEFJ063rn5n46OwkOmSl3mHyrdI14NDYH2CHqAqKp3BECZ2/MpxYaIVnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jscpd/badge-reporter": "4.1.0",
-        "@jscpd/core": "4.1.0",
-        "@jscpd/finder": "4.1.0",
-        "@jscpd/html-reporter": "4.1.0",
-        "@jscpd/tokenizer": "4.1.0",
+        "@jscpd/badge-reporter": "4.2.0",
+        "@jscpd/core": "4.2.0",
+        "@jscpd/finder": "4.2.0",
+        "@jscpd/html-reporter": "4.2.0",
+        "@jscpd/tokenizer": "4.2.0",
         "colors": "^1.4.0",
         "commander": "^5.0.0",
         "fs-extra": "^11.2.0",
-        "jscpd-sarif-reporter": "4.1.0"
+        "jscpd-sarif-reporter": "4.2.0"
       },
       "bin": {
         "jscpd": "bin/jscpd"
       }
     },
     "node_modules/jscpd-sarif-reporter": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jscpd-sarif-reporter/-/jscpd-sarif-reporter-4.1.0.tgz",
-      "integrity": "sha512-D2JEDLrbt/aUahjhBLzgNtVrrRJ7UuWBBNkiwXXBh3wQ7+FRRL5T6TilBCFEu+2Plvmo/UygXyZXO8dOJM3mww==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/jscpd-sarif-reporter/-/jscpd-sarif-reporter-4.2.0.tgz",
+      "integrity": "sha512-v/RyDPJDJTHm03P/GUrd5i9EqSyUKXVH/U5tY0ODSQIoPJvAA9ISTyxzOct03KyWHHR8cSqdZzsG2sBSHQHLwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8060,16 +8059,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/prismjs": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
-      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/progress": {
       "version": "2.0.3",
       "dev": true,
@@ -8840,6 +8829,13 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
     },
     "node_modules/stackback": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "lint:unused:prod": "knip --config knip.production.json --reporter compact --production",
     "typecheck": "tsc --noEmit",
     "typecheck:test": "tsc --noEmit -p tsconfig.test.json",
-    "prepare": "husky || true"
+    "prepare": "husky || true",
+    "mutation:backend": "python3 scripts/run_backend_mutation.py"
   },
   "keywords": [
     "home-assistant",
@@ -61,7 +62,7 @@
     "eslint": "^10.3.0",
     "globals": "^17.6.0",
     "husky": "^9.0.0",
-    "jscpd": "^4.1.0",
+    "jscpd": "^4.2.0",
     "jsdom": "^29.1.1",
     "knip": "^6.12.2",
     "lint-staged": "^17.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,4 +78,4 @@ show_missing = true
 
 [tool.mutmut]
 paths_to_mutate = ["custom_components/autosnooze/"]
-tests_dir = ["tests/test_models_coverage.py", "tests/test_services_coverage.py", "tests/test_coordinator.py", "tests/test_sensor_coverage.py", "tests/test_persistence_robustness.py", "tests/test_init.py", "tests/test_validation_edge_cases.py"]
+tests_dir = ["tests/test_models_coverage.py", "tests/test_services_coverage.py", "tests/test_coordinator.py", "tests/test_sensor_coverage.py", "tests/test_persistence_robustness.py", "tests/test_init.py", "tests/test_validation_edge_cases.py", "tests/test_logging_utils.py", "tests/test_runtime_modules.py", "tests/test_application_commands.py", "tests/test_application_pause.py", "tests/test_application_setup.py"]

--- a/scripts/run_backend_mutation.py
+++ b/scripts/run_backend_mutation.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Run backend mutmut mutants without mutmut's forked pytest worker."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+from subprocess import DEVNULL, PIPE, TimeoutExpired, run
+import sys
+from time import monotonic
+from typing import Iterable
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_HA_PYTEST = Path("/Users/matt/Desktop/Projects/autodoctor/venv_test/bin/pytest")
+DEFAULT_HA_SITE_PACKAGES = Path(
+    "/Users/matt/Desktop/Projects/autodoctor/venv_test/lib/python3.14/site-packages"
+)
+SOURCE_INSPECTION_EXCLUSION = "not TestLovelaceResourceSafety"
+
+STATUS_KILLED = "killed"
+STATUS_SURVIVED = "survived"
+STATUS_NO_TESTS = "no tests"
+STATUS_TIMEOUT = "timeout"
+STATUS_CRASHED = "crashed"
+
+MUTMUT_EXIT_CODES = {
+    STATUS_KILLED: 1,
+    STATUS_SURVIVED: 0,
+    STATUS_NO_TESTS: 33,
+    STATUS_TIMEOUT: 36,
+    STATUS_CRASHED: -11,
+}
+
+
+def _find_mutmut_python() -> Path | None:
+    mutmut_path = shutil.which("mutmut")
+    if not mutmut_path:
+        return None
+
+    first_line = Path(mutmut_path).read_text(encoding="utf-8").splitlines()[0]
+    if not first_line.startswith("#!"):
+        return None
+    python_path = Path(first_line[2:].strip())
+    return python_path if python_path.exists() else None
+
+
+def _ensure_mutmut_importable() -> None:
+    try:
+        import mutmut.__main__  # noqa: F401
+    except ModuleNotFoundError:
+        if os.environ.get("AUTOSNOOZE_MUTATION_REEXEC") == "1":
+            raise
+
+        mutmut_python = _find_mutmut_python()
+        if mutmut_python is None:
+            raise SystemExit(
+                "mutmut is not importable and no mutmut executable with a Python shebang was found"
+            )
+
+        env = os.environ.copy()
+        env["AUTOSNOOZE_MUTATION_REEXEC"] = "1"
+        os.execve(mutmut_python, [str(mutmut_python), str(Path(__file__)), *sys.argv[1:]], env)
+
+
+def _add_import_path(path: Path) -> None:
+    if path.exists():
+        path_text = str(path)
+        if path_text not in sys.path:
+            sys.path.insert(0, path_text)
+
+
+def _load_mutmut(ha_site_packages: Path):
+    _add_import_path(ha_site_packages)
+    _ensure_mutmut_importable()
+
+    import mutmut.__main__ as mutmut_main
+
+    return mutmut_main
+
+
+def _configure_mutmut(mutmut_main, exclude_source_inspection_tests: bool) -> None:
+    mutmut_main.ensure_config_loaded()
+    if exclude_source_inspection_tests:
+        args = mutmut_main.mutmut.config.pytest_add_cli_args
+        exclusion = ["-k", SOURCE_INSPECTION_EXCLUSION]
+        if exclusion != args[:2]:
+            mutmut_main.mutmut.config.pytest_add_cli_args = exclusion + args
+
+
+def _bootstrap_mutants(mutmut_main, max_children: int, refresh_stats: bool) -> None:
+    os.environ["MUTANT_UNDER_TEST"] = "mutant_generation"
+    (PROJECT_ROOT / "mutants").mkdir(exist_ok=True)
+
+    mutmut_main.copy_src_dir()
+    mutmut_main.copy_also_copy_files()
+    mutmut_main.setup_source_paths()
+    mutmut_main.store_lines_covered_by_tests()
+    mutmut_main.create_mutants(max_children)
+
+    stats_path = PROJECT_ROOT / "mutants" / "mutmut-stats.json"
+    if refresh_stats and stats_path.exists():
+        stats_path.unlink()
+
+    runner = mutmut_main.PytestRunner()
+    runner.prepare_main_test_run()
+    mutmut_main.collect_or_load_stats(runner)
+
+
+def _pytest_command(pytest_path: Path, tests: Iterable[str], exclude_source_inspection_tests: bool) -> list[str]:
+    command = [str(pytest_path), "--rootdir=.", "--tb=short", "-x", "-q"]
+    if exclude_source_inspection_tests:
+        command += ["-k", SOURCE_INSPECTION_EXCLUSION]
+    command += sorted(tests)
+    return command
+
+
+def _mutation_env(mutant_name: str, ha_site_packages: Path, mutmut_main) -> dict[str, str]:
+    env = os.environ.copy()
+    env["MUTANT_UNDER_TEST"] = mutant_name
+
+    mutmut_site_packages = str(Path(mutmut_main.__file__).resolve().parents[1])
+    python_path_parts = [
+        mutmut_site_packages,
+        str(ha_site_packages),
+        env.get("PYTHONPATH", ""),
+    ]
+    env["PYTHONPATH"] = os.pathsep.join(part for part in python_path_parts if part)
+    return env
+
+
+def _classify_return_code(return_code: int) -> str:
+    if return_code == 0:
+        return STATUS_SURVIVED
+    if return_code == 5:
+        return STATUS_NO_TESTS
+    if return_code < 0:
+        return STATUS_CRASHED
+    return STATUS_KILLED
+
+
+def _tests_for_mutant(mutmut_main, mutant_name: str) -> set[str]:
+    normalized_name = mutant_name.replace("__init__.", "")
+    mangled_name = mutmut_main.mangled_name_from_mutant_name(normalized_name)
+    return set(mutmut_main.mutmut.tests_by_mangled_function_name.get(mangled_name, set()))
+
+
+def _estimated_timeout(mutmut_main, tests: set[str]) -> float:
+    duration = sum(mutmut_main.mutmut.duration_by_test.get(test_name, 0) for test_name in tests)
+    return max(10.0, (duration + 1.0) * 30.0)
+
+
+def _record_result(mutant_data, mutant_name: str, status: str, duration: float) -> None:
+    mutant_data.exit_code_by_key[mutant_name] = MUTMUT_EXIT_CODES[status]
+    mutant_data.durations_by_key[mutant_name] = duration
+    mutant_data.save()
+
+
+def _run_mutant(
+    *,
+    mutmut_main,
+    mutant_data,
+    mutant_name: str,
+    pytest_path: Path,
+    ha_site_packages: Path,
+    exclude_source_inspection_tests: bool,
+) -> str:
+    tests = _tests_for_mutant(mutmut_main, mutant_name)
+    if not tests:
+        _record_result(mutant_data, mutant_name, STATUS_NO_TESTS, 0.0)
+        return STATUS_NO_TESTS
+
+    command = _pytest_command(pytest_path, tests, exclude_source_inspection_tests)
+    env = _mutation_env(mutant_name, ha_site_packages, mutmut_main)
+    started_at = monotonic()
+    try:
+        result = run(
+            command,
+            cwd=PROJECT_ROOT / "mutants",
+            env=env,
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
+            timeout=_estimated_timeout(mutmut_main, tests),
+            check=False,
+        )
+    except TimeoutExpired:
+        status = STATUS_TIMEOUT
+    else:
+        status = _classify_return_code(result.returncode)
+
+    _record_result(mutant_data, mutant_name, status, monotonic() - started_at)
+    return status
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mutants", nargs="*", help="Optional mutmut names or glob patterns to run")
+    parser.add_argument("--max-children", type=int, default=8, help="Parallelism for mutmut generation")
+    parser.add_argument("--limit", type=int, help="Run only the first N matching mutants")
+    parser.add_argument(
+        "--pytest",
+        type=Path,
+        default=Path(os.environ.get("AUTOSNOOZE_HA_PYTEST", DEFAULT_HA_PYTEST)),
+        help="pytest executable with Home Assistant test dependencies",
+    )
+    parser.add_argument(
+        "--ha-site-packages",
+        type=Path,
+        default=Path(
+            os.environ.get("AUTOSNOOZE_HA_SITE_PACKAGES", DEFAULT_HA_SITE_PACKAGES)
+        ),
+        help="site-packages path containing Home Assistant test dependencies",
+    )
+    parser.add_argument(
+        "--include-source-inspection-tests",
+        action="store_true",
+        help="Do not exclude source-text tests that inspect mutmut's generated source copy",
+    )
+    parser.add_argument(
+        "--reuse-stats",
+        action="store_true",
+        help="Reuse mutants/mutmut-stats.json instead of refreshing stats",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    if not args.pytest.exists():
+        raise SystemExit(f"pytest executable not found: {args.pytest}")
+    if not args.ha_site_packages.exists():
+        raise SystemExit(f"Home Assistant site-packages not found: {args.ha_site_packages}")
+
+    os.chdir(PROJECT_ROOT)
+    exclude_source_inspection_tests = not args.include_source_inspection_tests
+    mutmut_main = _load_mutmut(args.ha_site_packages)
+    _configure_mutmut(mutmut_main, exclude_source_inspection_tests)
+    _bootstrap_mutants(mutmut_main, args.max_children, refresh_stats=not args.reuse_stats)
+
+    mutants, _source_file_mutation_data_by_path = mutmut_main.collect_source_file_mutation_data(
+        mutant_names=args.mutants
+    )
+    if args.limit is not None:
+        mutants = mutants[: args.limit]
+
+    counts = {
+        STATUS_KILLED: 0,
+        STATUS_SURVIVED: 0,
+        STATUS_NO_TESTS: 0,
+        STATUS_TIMEOUT: 0,
+        STATUS_CRASHED: 0,
+    }
+    for index, (mutant_data, mutant_name, _previous_result) in enumerate(mutants, start=1):
+        status = _run_mutant(
+            mutmut_main=mutmut_main,
+            mutant_data=mutant_data,
+            mutant_name=mutant_name,
+            pytest_path=args.pytest,
+            ha_site_packages=args.ha_site_packages,
+            exclude_source_inspection_tests=exclude_source_inspection_tests,
+        )
+        counts[status] += 1
+        print(f"{index}/{len(mutants)} {status}: {mutant_name}", flush=True)
+
+    print("Backend mutation summary")
+    for status, count in counts.items():
+        print(f"{status}: {count}")
+
+    return 1 if counts[STATUS_SURVIVED] or counts[STATUS_TIMEOUT] or counts[STATUS_CRASHED] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/components/autosnooze-actions-controller.ts
+++ b/src/components/autosnooze-actions-controller.ts
@@ -8,8 +8,6 @@ import type { PauseServiceParams } from '../types/automation.js';
 import {
   runPauseActionFeature,
   runPauseFeature,
-  type RunPauseFeatureInput,
-  type RunPauseFeatureResult,
 } from '../features/pause/index.js';
 import {
   runUndoFeature,
@@ -26,7 +24,10 @@ import {
 
 export { validateScheduledPauseInput as validateCardScheduledPauseInput };
 
-export async function runCardPauseAction(input: RunPauseFeatureInput): Promise<RunPauseFeatureResult> {
+type RunCardPauseInput = Parameters<typeof runPauseFeature>[0];
+type RunCardPauseResult = Awaited<ReturnType<typeof runPauseFeature>>;
+
+export async function runCardPauseAction(input: RunCardPauseInput): Promise<RunCardPauseResult> {
   return runPauseFeature(input);
 }
 

--- a/src/components/autosnooze-actions-controller.ts
+++ b/src/components/autosnooze-actions-controller.ts
@@ -5,16 +5,30 @@
 
 import type { HomeAssistant } from '../types/hass.js';
 import type { PauseServiceParams } from '../types/automation.js';
-import { runPauseActionFeature } from '../features/pause/index.js';
+import {
+  runPauseActionFeature,
+  runPauseFeature,
+  type RunPauseFeatureInput,
+  type RunPauseFeatureResult,
+} from '../features/pause/index.js';
 import {
   runUndoFeature,
   runWakeAllFeature,
   runWakeFeature,
 } from '../features/resume/index.js';
 import {
+  runAdjustFeature,
   runAdjustActionFeature,
   runCancelScheduledActionFeature,
+  runCancelScheduledFeature,
+  validateScheduledPauseInput,
 } from '../features/scheduled-snooze/index.js';
+
+export { validateScheduledPauseInput as validateCardScheduledPauseInput };
+
+export async function runCardPauseAction(input: RunPauseFeatureInput): Promise<RunPauseFeatureResult> {
+  return runPauseFeature(input);
+}
 
 export async function runPauseAction(hass: HomeAssistant, params: PauseServiceParams): Promise<void> {
   await runPauseActionFeature(hass, params);
@@ -30,6 +44,18 @@ export async function runWakeAllAction(hass: HomeAssistant): Promise<void> {
 
 export async function runCancelScheduledAction(hass: HomeAssistant, entityId: string): Promise<void> {
   await runCancelScheduledActionFeature(hass, entityId);
+}
+
+export async function runCardCancelScheduledAction(hass: HomeAssistant, entityId: string): Promise<void> {
+  await runCancelScheduledFeature(hass, entityId);
+}
+
+export async function runCardAdjustAction(
+  hass: HomeAssistant,
+  detail: { entityId?: string; entityIds?: string[]; days?: number; hours?: number; minutes?: number },
+  currentResumeAt: string
+): Promise<{ nextResumeAt: string }> {
+  return runAdjustFeature(hass, detail, currentResumeAt);
 }
 
 export async function runAdjustAction(

--- a/tests/test_application_commands.py
+++ b/tests/test_application_commands.py
@@ -11,36 +11,6 @@ from homeassistant.exceptions import ServiceValidationError
 
 
 @pytest.mark.asyncio
-async def test_resume_batch_wrapper_requires_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Resume wrapper fails clearly before service dependencies are configured."""
-    from custom_components.autosnooze.application import resume
-    from custom_components.autosnooze.models import AutomationPauseData
-
-    monkeypatch.setattr(resume, "_resume_batch_impl", None)
-
-    with pytest.raises(RuntimeError, match="^Resume batch implementation is not configured$"):
-        await resume.async_resume_batch(MagicMock(), AutomationPauseData(store=MagicMock()), ["automation.a"])
-
-
-@pytest.mark.asyncio
-async def test_resume_batch_wrapper_forwards_configured_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Resume wrapper delegates the full call contract to the configured implementation."""
-    from custom_components.autosnooze.application import resume
-    from custom_components.autosnooze.models import AutomationPauseData
-
-    monkeypatch.setattr(resume, "_resume_batch_impl", None)
-    batch_resume = AsyncMock()
-    hass = MagicMock()
-    data = AutomationPauseData(store=MagicMock())
-    entity_ids = ["automation.a"]
-
-    resume.configure_resume_dependencies(resume_batch=batch_resume)
-    await resume.async_resume_batch(hass, data, entity_ids)
-
-    batch_resume.assert_awaited_once_with(hass, data, entity_ids)
-
-
-@pytest.mark.asyncio
 async def test_handle_cancel_service_filters_unknown_entities() -> None:
     """Cancel application batches only paused entities."""
     from custom_components.autosnooze.application.resume import async_handle_cancel_service
@@ -65,7 +35,7 @@ async def test_handle_cancel_service_filters_unknown_entities() -> None:
 async def test_handle_cancel_service_continues_after_leading_unknown_entity() -> None:
     """Cancel application keeps scanning after unknown entity ids."""
     from custom_components.autosnooze.application.resume import async_handle_cancel_service
-    from custom_components.autosnooze.models import AutomationPauseData
+    from custom_components.autosnooze.runtime.state import AutomationPauseData
 
     hass = MagicMock()
     data = AutomationPauseData(store=MagicMock())
@@ -86,7 +56,7 @@ async def test_handle_cancel_service_continues_after_leading_unknown_entity() ->
 async def test_handle_cancel_all_service_batches_all_paused_entities() -> None:
     """Cancel-all application delegates every paused entity id."""
     from custom_components.autosnooze.application.resume import async_handle_cancel_all_service
-    from custom_components.autosnooze.models import AutomationPauseData
+    from custom_components.autosnooze.runtime.state import AutomationPauseData
 
     hass = MagicMock()
     data = AutomationPauseData(store=MagicMock())
@@ -100,42 +70,6 @@ async def test_handle_cancel_all_service_batches_all_paused_entities() -> None:
         await async_handle_cancel_all_service(hass, data)
 
     batch_resume.assert_awaited_once_with(hass, data, ["automation.a", "automation.b"])
-
-
-@pytest.mark.asyncio
-async def test_scheduled_batch_wrapper_requires_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Scheduled wrapper fails clearly before service dependencies are configured."""
-    from custom_components.autosnooze.application import scheduled
-    from custom_components.autosnooze.models import AutomationPauseData
-
-    monkeypatch.setattr(scheduled, "_cancel_scheduled_batch_impl", None)
-
-    with pytest.raises(RuntimeError, match="^Cancel scheduled batch implementation is not configured$"):
-        await scheduled.async_cancel_scheduled_batch(
-            MagicMock(),
-            AutomationPauseData(store=MagicMock()),
-            ["automation.a"],
-        )
-
-
-@pytest.mark.asyncio
-async def test_scheduled_batch_wrapper_forwards_configured_dependency(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Scheduled wrapper delegates the full call contract to the configured implementation."""
-    from custom_components.autosnooze.application import scheduled
-    from custom_components.autosnooze.models import AutomationPauseData
-
-    monkeypatch.setattr(scheduled, "_cancel_scheduled_batch_impl", None)
-    batch_cancel = AsyncMock()
-    hass = MagicMock()
-    data = AutomationPauseData(store=MagicMock())
-    entity_ids = ["automation.a"]
-
-    scheduled.configure_scheduled_dependencies(cancel_scheduled_batch=batch_cancel)
-    await scheduled.async_cancel_scheduled_batch(hass, data, entity_ids)
-
-    batch_cancel.assert_awaited_once_with(hass, data, entity_ids)
 
 
 @pytest.mark.asyncio
@@ -163,7 +97,7 @@ async def test_handle_cancel_scheduled_service_filters_unknown_entities() -> Non
 async def test_handle_cancel_scheduled_service_continues_after_leading_unknown_entity() -> None:
     """Scheduled cancel application keeps scanning after unknown entity ids."""
     from custom_components.autosnooze.application.scheduled import async_handle_cancel_scheduled_service
-    from custom_components.autosnooze.models import AutomationPauseData
+    from custom_components.autosnooze.runtime.state import AutomationPauseData
 
     hass = MagicMock()
     data = AutomationPauseData(store=MagicMock())
@@ -178,42 +112,6 @@ async def test_handle_cancel_scheduled_service_continues_after_leading_unknown_e
         await async_handle_cancel_scheduled_service(hass, data, call)
 
     batch_cancel.assert_awaited_once_with(hass, data, ["automation.exists"])
-
-
-@pytest.mark.asyncio
-async def test_adjust_batch_wrapper_requires_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Adjust wrapper fails clearly before service dependencies are configured."""
-    from custom_components.autosnooze.application import adjust
-    from custom_components.autosnooze.models import AutomationPauseData
-
-    monkeypatch.setattr(adjust, "_adjust_batch_impl", None)
-
-    with pytest.raises(RuntimeError, match="^Adjust batch implementation is not configured$"):
-        await adjust.async_adjust_snooze_batch(
-            MagicMock(),
-            AutomationPauseData(store=MagicMock()),
-            ["automation.a"],
-            timedelta(minutes=5),
-        )
-
-
-@pytest.mark.asyncio
-async def test_adjust_batch_wrapper_forwards_configured_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Adjust wrapper delegates the full call contract to the configured implementation."""
-    from custom_components.autosnooze.application import adjust
-    from custom_components.autosnooze.models import AutomationPauseData
-
-    monkeypatch.setattr(adjust, "_adjust_batch_impl", None)
-    batch_adjust = AsyncMock()
-    hass = MagicMock()
-    data = AutomationPauseData(store=MagicMock())
-    entity_ids = ["automation.a"]
-    delta = timedelta(minutes=5)
-
-    adjust.configure_adjust_dependencies(adjust_batch=batch_adjust)
-    await adjust.async_adjust_snooze_batch(hass, data, entity_ids, delta)
-
-    batch_adjust.assert_awaited_once_with(hass, data, entity_ids, delta)
 
 
 @pytest.mark.asyncio
@@ -240,7 +138,7 @@ async def test_handle_adjust_service_builds_delta_and_calls_batch_adjust() -> No
 async def test_handle_adjust_service_builds_delta_from_all_duration_fields() -> None:
     """Adjust application reads days, hours, and minutes from the service call."""
     from custom_components.autosnooze.application.adjust import async_handle_adjust_service
-    from custom_components.autosnooze.models import AutomationPauseData
+    from custom_components.autosnooze.runtime.state import AutomationPauseData
 
     hass = MagicMock()
     data = AutomationPauseData(store=MagicMock())
@@ -261,7 +159,7 @@ async def test_handle_adjust_service_rejects_zero_adjustment() -> None:
     """Adjust application rejects calls that omit all duration fields."""
     from custom_components.autosnooze.application.adjust import async_handle_adjust_service
     from custom_components.autosnooze.const import DOMAIN
-    from custom_components.autosnooze.models import AutomationPauseData
+    from custom_components.autosnooze.runtime.state import AutomationPauseData
 
     hass = MagicMock()
     data = AutomationPauseData(store=MagicMock())

--- a/tests/test_application_commands.py
+++ b/tests/test_application_commands.py
@@ -7,6 +7,37 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.exceptions import ServiceValidationError
+
+
+@pytest.mark.asyncio
+async def test_resume_batch_wrapper_requires_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resume wrapper fails clearly before service dependencies are configured."""
+    from custom_components.autosnooze.application import resume
+    from custom_components.autosnooze.models import AutomationPauseData
+
+    monkeypatch.setattr(resume, "_resume_batch_impl", None)
+
+    with pytest.raises(RuntimeError, match="^Resume batch implementation is not configured$"):
+        await resume.async_resume_batch(MagicMock(), AutomationPauseData(store=MagicMock()), ["automation.a"])
+
+
+@pytest.mark.asyncio
+async def test_resume_batch_wrapper_forwards_configured_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resume wrapper delegates the full call contract to the configured implementation."""
+    from custom_components.autosnooze.application import resume
+    from custom_components.autosnooze.models import AutomationPauseData
+
+    monkeypatch.setattr(resume, "_resume_batch_impl", None)
+    batch_resume = AsyncMock()
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    entity_ids = ["automation.a"]
+
+    resume.configure_resume_dependencies(resume_batch=batch_resume)
+    await resume.async_resume_batch(hass, data, entity_ids)
+
+    batch_resume.assert_awaited_once_with(hass, data, entity_ids)
 
 
 @pytest.mark.asyncio
@@ -31,6 +62,83 @@ async def test_handle_cancel_service_filters_unknown_entities() -> None:
 
 
 @pytest.mark.asyncio
+async def test_handle_cancel_service_continues_after_leading_unknown_entity() -> None:
+    """Cancel application keeps scanning after unknown entity ids."""
+    from custom_components.autosnooze.application.resume import async_handle_cancel_service
+    from custom_components.autosnooze.models import AutomationPauseData
+
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    data.paused["automation.exists"] = MagicMock()
+    call = MagicMock()
+    call.data = {ATTR_ENTITY_ID: ["automation.missing", "automation.exists"]}
+
+    with patch(
+        "custom_components.autosnooze.application.resume.async_resume_batch",
+        new_callable=AsyncMock,
+    ) as batch_resume:
+        await async_handle_cancel_service(hass, data, call)
+
+    batch_resume.assert_awaited_once_with(hass, data, ["automation.exists"])
+
+
+@pytest.mark.asyncio
+async def test_handle_cancel_all_service_batches_all_paused_entities() -> None:
+    """Cancel-all application delegates every paused entity id."""
+    from custom_components.autosnooze.application.resume import async_handle_cancel_all_service
+    from custom_components.autosnooze.models import AutomationPauseData
+
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    data.paused["automation.a"] = MagicMock()
+    data.paused["automation.b"] = MagicMock()
+
+    with patch(
+        "custom_components.autosnooze.application.resume.async_resume_batch",
+        new_callable=AsyncMock,
+    ) as batch_resume:
+        await async_handle_cancel_all_service(hass, data)
+
+    batch_resume.assert_awaited_once_with(hass, data, ["automation.a", "automation.b"])
+
+
+@pytest.mark.asyncio
+async def test_scheduled_batch_wrapper_requires_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scheduled wrapper fails clearly before service dependencies are configured."""
+    from custom_components.autosnooze.application import scheduled
+    from custom_components.autosnooze.models import AutomationPauseData
+
+    monkeypatch.setattr(scheduled, "_cancel_scheduled_batch_impl", None)
+
+    with pytest.raises(RuntimeError, match="^Cancel scheduled batch implementation is not configured$"):
+        await scheduled.async_cancel_scheduled_batch(
+            MagicMock(),
+            AutomationPauseData(store=MagicMock()),
+            ["automation.a"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_scheduled_batch_wrapper_forwards_configured_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scheduled wrapper delegates the full call contract to the configured implementation."""
+    from custom_components.autosnooze.application import scheduled
+    from custom_components.autosnooze.models import AutomationPauseData
+
+    monkeypatch.setattr(scheduled, "_cancel_scheduled_batch_impl", None)
+    batch_cancel = AsyncMock()
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    entity_ids = ["automation.a"]
+
+    scheduled.configure_scheduled_dependencies(cancel_scheduled_batch=batch_cancel)
+    await scheduled.async_cancel_scheduled_batch(hass, data, entity_ids)
+
+    batch_cancel.assert_awaited_once_with(hass, data, entity_ids)
+
+
+@pytest.mark.asyncio
 async def test_handle_cancel_scheduled_service_filters_unknown_entities() -> None:
     """Scheduled cancel application batches only scheduled entities."""
     from custom_components.autosnooze.application.scheduled import async_handle_cancel_scheduled_service
@@ -52,6 +160,63 @@ async def test_handle_cancel_scheduled_service_filters_unknown_entities() -> Non
 
 
 @pytest.mark.asyncio
+async def test_handle_cancel_scheduled_service_continues_after_leading_unknown_entity() -> None:
+    """Scheduled cancel application keeps scanning after unknown entity ids."""
+    from custom_components.autosnooze.application.scheduled import async_handle_cancel_scheduled_service
+    from custom_components.autosnooze.models import AutomationPauseData
+
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    data.scheduled["automation.exists"] = MagicMock()
+    call = MagicMock()
+    call.data = {ATTR_ENTITY_ID: ["automation.missing", "automation.exists"]}
+
+    with patch(
+        "custom_components.autosnooze.application.scheduled.async_cancel_scheduled_batch",
+        new_callable=AsyncMock,
+    ) as batch_cancel:
+        await async_handle_cancel_scheduled_service(hass, data, call)
+
+    batch_cancel.assert_awaited_once_with(hass, data, ["automation.exists"])
+
+
+@pytest.mark.asyncio
+async def test_adjust_batch_wrapper_requires_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Adjust wrapper fails clearly before service dependencies are configured."""
+    from custom_components.autosnooze.application import adjust
+    from custom_components.autosnooze.models import AutomationPauseData
+
+    monkeypatch.setattr(adjust, "_adjust_batch_impl", None)
+
+    with pytest.raises(RuntimeError, match="^Adjust batch implementation is not configured$"):
+        await adjust.async_adjust_snooze_batch(
+            MagicMock(),
+            AutomationPauseData(store=MagicMock()),
+            ["automation.a"],
+            timedelta(minutes=5),
+        )
+
+
+@pytest.mark.asyncio
+async def test_adjust_batch_wrapper_forwards_configured_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Adjust wrapper delegates the full call contract to the configured implementation."""
+    from custom_components.autosnooze.application import adjust
+    from custom_components.autosnooze.models import AutomationPauseData
+
+    monkeypatch.setattr(adjust, "_adjust_batch_impl", None)
+    batch_adjust = AsyncMock()
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    entity_ids = ["automation.a"]
+    delta = timedelta(minutes=5)
+
+    adjust.configure_adjust_dependencies(adjust_batch=batch_adjust)
+    await adjust.async_adjust_snooze_batch(hass, data, entity_ids, delta)
+
+    batch_adjust.assert_awaited_once_with(hass, data, entity_ids, delta)
+
+
+@pytest.mark.asyncio
 async def test_handle_adjust_service_builds_delta_and_calls_batch_adjust() -> None:
     """Adjust application computes timedelta and delegates."""
     from custom_components.autosnooze.application.adjust import async_handle_adjust_service
@@ -69,3 +234,43 @@ async def test_handle_adjust_service_builds_delta_and_calls_batch_adjust() -> No
         await async_handle_adjust_service(hass, data, call)
 
     batch_adjust.assert_called_once_with(hass, data, ["automation.a"], timedelta(hours=1, minutes=15))
+
+
+@pytest.mark.asyncio
+async def test_handle_adjust_service_builds_delta_from_all_duration_fields() -> None:
+    """Adjust application reads days, hours, and minutes from the service call."""
+    from custom_components.autosnooze.application.adjust import async_handle_adjust_service
+    from custom_components.autosnooze.models import AutomationPauseData
+
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    call = MagicMock()
+    call.data = {ATTR_ENTITY_ID: ["automation.a"], "days": 2, "hours": 3, "minutes": 4}
+
+    with patch(
+        "custom_components.autosnooze.application.adjust.async_adjust_snooze_batch",
+        new_callable=AsyncMock,
+    ) as batch_adjust:
+        await async_handle_adjust_service(hass, data, call)
+
+    batch_adjust.assert_awaited_once_with(hass, data, ["automation.a"], timedelta(days=2, hours=3, minutes=4))
+
+
+@pytest.mark.asyncio
+async def test_handle_adjust_service_rejects_zero_adjustment() -> None:
+    """Adjust application rejects calls that omit all duration fields."""
+    from custom_components.autosnooze.application.adjust import async_handle_adjust_service
+    from custom_components.autosnooze.const import DOMAIN
+    from custom_components.autosnooze.models import AutomationPauseData
+
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    call = MagicMock()
+    call.data = {ATTR_ENTITY_ID: ["automation.a"]}
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await async_handle_adjust_service(hass, data, call)
+
+    assert str(exc_info.value) == "Adjustment must be non-zero"
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "invalid_adjustment"

--- a/tests/test_application_pause.py
+++ b/tests/test_application_pause.py
@@ -11,65 +11,6 @@ from homeassistant.const import ATTR_ENTITY_ID
 UTC = timezone.utc
 
 
-def test_validate_guardrails_wrapper_requires_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Guardrail wrapper fails clearly before dependencies are configured."""
-    from custom_components.autosnooze.application import pause
-
-    monkeypatch.setattr(pause, "_guardrail_validator", None)
-
-    with pytest.raises(RuntimeError, match="^Pause guardrail validator is not configured$"):
-        pause._validate_guardrails(MagicMock(), ["automation.a"])
-
-
-def test_validate_guardrails_wrapper_defaults_confirm_false(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Guardrail wrapper defaults confirm to false and forwards all arguments."""
-    from custom_components.autosnooze.application import pause
-
-    validate_guardrails = MagicMock()
-    hass = MagicMock()
-    entity_ids = ["automation.a"]
-    monkeypatch.setattr(pause, "_guardrail_validator", validate_guardrails)
-
-    pause._validate_guardrails(hass, entity_ids)
-
-    validate_guardrails.assert_called_once_with(hass, entity_ids, False)
-
-
-@pytest.mark.asyncio
-async def test_pause_automations_wrapper_requires_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Pause wrapper fails clearly before dependencies are configured."""
-    from custom_components.autosnooze.application import pause
-    from custom_components.autosnooze.models import AutomationPauseData
-
-    monkeypatch.setattr(pause, "_pause_automations_impl", None)
-
-    with pytest.raises(RuntimeError, match="^Pause implementation is not configured$"):
-        await pause.async_pause_automations(
-            MagicMock(),
-            AutomationPauseData(store=MagicMock()),
-            ["automation.a"],
-        )
-
-
-@pytest.mark.asyncio
-async def test_pause_automations_wrapper_defaults_and_forwards_dependency(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Pause wrapper defaults duration fields and forwards the full call contract."""
-    from custom_components.autosnooze.application import pause
-    from custom_components.autosnooze.models import AutomationPauseData
-
-    pause_automations = AsyncMock()
-    hass = MagicMock()
-    data = AutomationPauseData(store=MagicMock())
-    entity_ids = ["automation.a"]
-    monkeypatch.setattr(pause, "_pause_automations_impl", pause_automations)
-
-    await pause.async_pause_automations(hass, data, entity_ids)
-
-    pause_automations.assert_awaited_once_with(hass, data, entity_ids, 0, 0, 0, None, None)
-
-
 @pytest.mark.asyncio
 async def test_handle_pause_service_forwards_full_contract_fields() -> None:
     """Pause application delegates guardrails and pause execution."""
@@ -117,7 +58,7 @@ async def test_handle_pause_service_forwards_full_contract_fields() -> None:
 async def test_handle_pause_service_forwards_default_contract_fields() -> None:
     """Pause application supplies default service fields when optional inputs are omitted."""
     from custom_components.autosnooze.application.pause import async_handle_pause_service
-    from custom_components.autosnooze.models import AutomationPauseData
+    from custom_components.autosnooze.runtime.state import AutomationPauseData
 
     mock_hass = MagicMock()
     data = AutomationPauseData(store=MagicMock())

--- a/tests/test_application_pause.py
+++ b/tests/test_application_pause.py
@@ -11,6 +11,65 @@ from homeassistant.const import ATTR_ENTITY_ID
 UTC = timezone.utc
 
 
+def test_validate_guardrails_wrapper_requires_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Guardrail wrapper fails clearly before dependencies are configured."""
+    from custom_components.autosnooze.application import pause
+
+    monkeypatch.setattr(pause, "_guardrail_validator", None)
+
+    with pytest.raises(RuntimeError, match="^Pause guardrail validator is not configured$"):
+        pause._validate_guardrails(MagicMock(), ["automation.a"])
+
+
+def test_validate_guardrails_wrapper_defaults_confirm_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Guardrail wrapper defaults confirm to false and forwards all arguments."""
+    from custom_components.autosnooze.application import pause
+
+    validate_guardrails = MagicMock()
+    hass = MagicMock()
+    entity_ids = ["automation.a"]
+    monkeypatch.setattr(pause, "_guardrail_validator", validate_guardrails)
+
+    pause._validate_guardrails(hass, entity_ids)
+
+    validate_guardrails.assert_called_once_with(hass, entity_ids, False)
+
+
+@pytest.mark.asyncio
+async def test_pause_automations_wrapper_requires_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pause wrapper fails clearly before dependencies are configured."""
+    from custom_components.autosnooze.application import pause
+    from custom_components.autosnooze.models import AutomationPauseData
+
+    monkeypatch.setattr(pause, "_pause_automations_impl", None)
+
+    with pytest.raises(RuntimeError, match="^Pause implementation is not configured$"):
+        await pause.async_pause_automations(
+            MagicMock(),
+            AutomationPauseData(store=MagicMock()),
+            ["automation.a"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_pause_automations_wrapper_defaults_and_forwards_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pause wrapper defaults duration fields and forwards the full call contract."""
+    from custom_components.autosnooze.application import pause
+    from custom_components.autosnooze.models import AutomationPauseData
+
+    pause_automations = AsyncMock()
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    entity_ids = ["automation.a"]
+    monkeypatch.setattr(pause, "_pause_automations_impl", pause_automations)
+
+    await pause.async_pause_automations(hass, data, entity_ids)
+
+    pause_automations.assert_awaited_once_with(hass, data, entity_ids, 0, 0, 0, None, None)
+
+
 @pytest.mark.asyncio
 async def test_handle_pause_service_forwards_full_contract_fields() -> None:
     """Pause application delegates guardrails and pause execution."""
@@ -51,6 +110,39 @@ async def test_handle_pause_service_forwards_full_contract_fields() -> None:
         3,
         disable_at,
         resume_at,
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_pause_service_forwards_default_contract_fields() -> None:
+    """Pause application supplies default service fields when optional inputs are omitted."""
+    from custom_components.autosnooze.application.pause import async_handle_pause_service
+    from custom_components.autosnooze.models import AutomationPauseData
+
+    mock_hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    call = MagicMock()
+    call.data = {ATTR_ENTITY_ID: ["automation.a"]}
+
+    with (
+        patch("custom_components.autosnooze.application.pause._validate_guardrails") as validate_guardrails,
+        patch(
+            "custom_components.autosnooze.application.pause.async_pause_automations",
+            new_callable=AsyncMock,
+        ) as pause_automations,
+    ):
+        await async_handle_pause_service(mock_hass, data, call)
+
+    validate_guardrails.assert_called_once_with(mock_hass, ["automation.a"], confirm=False)
+    pause_automations.assert_awaited_once_with(
+        mock_hass,
+        data,
+        ["automation.a"],
+        0,
+        0,
+        0,
+        None,
+        None,
     )
 
 

--- a/tests/test_application_setup.py
+++ b/tests/test_application_setup.py
@@ -19,20 +19,128 @@ async def test_application_setup_initializes_runtime_and_services() -> None:
     entry = MagicMock()
     entry.add_update_listener = MagicMock(return_value=MagicMock())
     entry.async_on_unload = MagicMock()
+    register_static_path = AsyncMock()
+    register_lovelace_resource = AsyncMock()
+    ensure_labels_exist = AsyncMock()
+    load_stored = AsyncMock()
+    register_services = MagicMock()
+    store = MagicMock()
+    data = AutomationPauseData(store=store, hass=hass)
+    storage_factory = MagicMock(return_value=store)
+    data_factory = MagicMock(return_value=data)
+    update_listener = AsyncMock()
+
+    result = await async_setup_integration_entry(
+        hass,
+        entry,
+        register_static_path=register_static_path,
+        register_lovelace_resource=register_lovelace_resource,
+        ensure_labels_exist=ensure_labels_exist,
+        load_stored=load_stored,
+        register_services=register_services,
+        storage_factory=storage_factory,
+        platforms=["sensor"],
+        update_listener=update_listener,
+        data_factory=data_factory,
+    )
+
+    assert result is True
+    storage_factory.assert_called_once_with()
+    data_factory.assert_called_once_with(store, hass)
+    assert entry.runtime_data is data
+    register_static_path.assert_awaited_once_with(hass)
+    register_lovelace_resource.assert_awaited_once_with(hass)
+    ensure_labels_exist.assert_awaited_once_with(hass)
+    load_stored.assert_awaited_once_with(hass, data)
+    register_services.assert_called_once_with(hass, data)
+    hass.config_entries.async_forward_entry_setups.assert_awaited_once_with(entry, ["sensor"])
+    entry.add_update_listener.assert_called_once_with(update_listener)
+    entry.async_on_unload.assert_called_once_with(entry.add_update_listener.return_value)
+
+
+@pytest.mark.asyncio
+async def test_application_setup_defers_startup_work_until_home_assistant_started() -> None:
+    """Setup helper registers startup work when Home Assistant is not running yet."""
+    from custom_components.autosnooze.application.setup import async_setup_integration_entry
+    from custom_components.autosnooze.models import AutomationPauseData
+
+    hass = MagicMock()
+    hass.is_running = False
+    hass.config_entries.async_forward_entry_setups = AsyncMock()
+    hass.bus.async_listen_once = MagicMock(return_value=MagicMock())
+    entry = MagicMock()
+    entry.add_update_listener = MagicMock(return_value=MagicMock())
+    entry.async_on_unload = MagicMock()
+    register_lovelace_resource = AsyncMock()
+    ensure_labels_exist = AsyncMock()
+    load_stored = AsyncMock()
+    store = MagicMock()
+    data = AutomationPauseData(store=store, hass=hass)
 
     await async_setup_integration_entry(
         hass,
         entry,
         register_static_path=AsyncMock(),
-        register_lovelace_resource=AsyncMock(),
-        ensure_labels_exist=AsyncMock(),
-        load_stored=AsyncMock(),
+        register_lovelace_resource=register_lovelace_resource,
+        ensure_labels_exist=ensure_labels_exist,
+        load_stored=load_stored,
         register_services=MagicMock(),
-        storage_factory=lambda: MagicMock(),
+        storage_factory=MagicMock(return_value=store),
         platforms=["sensor"],
         update_listener=AsyncMock(),
-        data_factory=lambda store, hass: AutomationPauseData(store=store, hass=hass),
+        data_factory=MagicMock(return_value=data),
     )
 
-    assert isinstance(entry.runtime_data, AutomationPauseData)
-    hass.config_entries.async_forward_entry_setups.assert_awaited_once_with(entry, ["sensor"])
+    hass.bus.async_listen_once.assert_called_once()
+    event_name, callback = hass.bus.async_listen_once.call_args.args
+    assert event_name == "homeassistant_started"
+    assert data.startup_listener_unsub is hass.bus.async_listen_once.return_value
+    register_lovelace_resource.assert_not_awaited()
+    ensure_labels_exist.assert_not_awaited()
+    load_stored.assert_not_awaited()
+
+    await callback(MagicMock())
+
+    register_lovelace_resource.assert_awaited_once_with(hass)
+    ensure_labels_exist.assert_awaited_once_with(hass)
+    load_stored.assert_awaited_once_with(hass, data)
+
+
+@pytest.mark.asyncio
+async def test_application_setup_startup_callback_noops_after_unload() -> None:
+    """Deferred startup work exits if the integration unloaded before startup."""
+    from custom_components.autosnooze.application.setup import async_setup_integration_entry
+    from custom_components.autosnooze.models import AutomationPauseData
+
+    hass = MagicMock()
+    hass.is_running = False
+    hass.config_entries.async_forward_entry_setups = AsyncMock()
+    hass.bus.async_listen_once = MagicMock(return_value=MagicMock())
+    entry = MagicMock()
+    entry.add_update_listener = MagicMock(return_value=MagicMock())
+    entry.async_on_unload = MagicMock()
+    register_lovelace_resource = AsyncMock()
+    ensure_labels_exist = AsyncMock()
+    load_stored = AsyncMock()
+    data = AutomationPauseData(store=MagicMock(), hass=hass, unloaded=True)
+
+    await async_setup_integration_entry(
+        hass,
+        entry,
+        register_static_path=AsyncMock(),
+        register_lovelace_resource=register_lovelace_resource,
+        ensure_labels_exist=ensure_labels_exist,
+        load_stored=load_stored,
+        register_services=MagicMock(),
+        storage_factory=MagicMock(return_value=MagicMock()),
+        platforms=["sensor"],
+        update_listener=AsyncMock(),
+        data_factory=MagicMock(return_value=data),
+    )
+
+    callback = hass.bus.async_listen_once.call_args.args[1]
+    await callback(MagicMock())
+
+    register_lovelace_resource.assert_not_awaited()
+    ensure_labels_exist.assert_not_awaited()
+    load_stored.assert_not_awaited()

--- a/tests/test_application_setup.py
+++ b/tests/test_application_setup.py
@@ -62,7 +62,7 @@ async def test_application_setup_initializes_runtime_and_services() -> None:
 async def test_application_setup_defers_startup_work_until_home_assistant_started() -> None:
     """Setup helper registers startup work when Home Assistant is not running yet."""
     from custom_components.autosnooze.application.setup import async_setup_integration_entry
-    from custom_components.autosnooze.models import AutomationPauseData
+    from custom_components.autosnooze.runtime.state import AutomationPauseData
 
     hass = MagicMock()
     hass.is_running = False
@@ -110,7 +110,7 @@ async def test_application_setup_defers_startup_work_until_home_assistant_starte
 async def test_application_setup_startup_callback_noops_after_unload() -> None:
     """Deferred startup work exits if the integration unloaded before startup."""
     from custom_components.autosnooze.application.setup import async_setup_integration_entry
-    from custom_components.autosnooze.models import AutomationPauseData
+    from custom_components.autosnooze.runtime.state import AutomationPauseData
 
     hass = MagicMock()
     hass.is_running = False

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+import logging
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME
@@ -381,6 +382,20 @@ class TestAsyncSave:
 
         assert result is False
         assert mock_store.async_save.call_count == 4  # Initial + 3 retries
+
+    @pytest.mark.asyncio
+    async def test_delegates_sleep_dependency_to_infrastructure_save(self) -> None:
+        """Coordinator save should inject its retry sleep dependency."""
+        data = AutomationPauseData()
+
+        with patch(
+            "custom_components.autosnooze.coordinator.infrastructure_async_save",
+            AsyncMock(return_value=True),
+        ) as mock_save:
+            result = await async_save(data)
+
+        assert result is True
+        mock_save.assert_awaited_once_with(data, sleep=asyncio.sleep)
 
 
 class TestAsyncLoadStoredLocking:
@@ -1766,6 +1781,19 @@ class TestAsyncCancelScheduled:
 
         listener.assert_called()
 
+    @pytest.mark.asyncio
+    async def test_logs_cancelled_entity(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test that successful cancellation logs the cancelled entity."""
+        mock_hass = MagicMock()
+        mock_store = MagicMock()
+        mock_store.async_save = AsyncMock()
+        data = AutomationPauseData(store=mock_store)
+
+        with caplog.at_level(logging.INFO, logger="custom_components.autosnooze.coordinator"):
+            await async_cancel_scheduled(mock_hass, data, "automation.test")
+
+        assert "Cancelled scheduled snooze for: automation.test" in caplog.messages
+
 
 class TestAsyncCancelScheduledBatch:
     """Tests for async_cancel_scheduled_batch function."""
@@ -1852,9 +1880,11 @@ class TestAsyncCancelScheduledBatch:
         mock_store.async_save = AsyncMock()
         data = AutomationPauseData(store=mock_store)
 
-        await async_cancel_scheduled_batch(mock_hass, data, [])
+        with patch("custom_components.autosnooze.coordinator._log_command") as mock_log_command:
+            await async_cancel_scheduled_batch(mock_hass, data, [])
 
         mock_store.async_save.assert_not_called()
+        mock_log_command.assert_called_once_with("cancel_scheduled", "success", ANY)
 
     @pytest.mark.asyncio
     async def test_skips_when_unloaded(self) -> None:
@@ -1865,9 +1895,39 @@ class TestAsyncCancelScheduledBatch:
         data = AutomationPauseData(store=mock_store)
         data.unloaded = True
 
-        await async_cancel_scheduled_batch(mock_hass, data, ["automation.test"])
+        with patch("custom_components.autosnooze.coordinator._log_command") as mock_log_command:
+            await async_cancel_scheduled_batch(mock_hass, data, ["automation.test"])
 
         mock_store.async_save.assert_not_called()
+        mock_log_command.assert_called_once_with("cancel_scheduled", "success", ANY)
+
+    @pytest.mark.asyncio
+    async def test_logs_cancelled_count(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test that successful batch cancellation logs the cancelled count."""
+        mock_hass = MagicMock()
+        mock_store = MagicMock()
+        mock_store.async_save = AsyncMock()
+        data = AutomationPauseData(store=mock_store)
+
+        with caplog.at_level(logging.INFO, logger="custom_components.autosnooze.coordinator"):
+            await async_cancel_scheduled_batch(mock_hass, data, ["automation.test1", "automation.test2"])
+
+        assert "Cancelled 2 scheduled snoozes" in caplog.messages
+
+    @pytest.mark.asyncio
+    async def test_save_failure_logs_error_outcome(self) -> None:
+        """Test that failed batch cancellation records error telemetry."""
+        mock_hass = MagicMock()
+        data = AutomationPauseData()
+
+        with (
+            patch("custom_components.autosnooze.coordinator.async_save", AsyncMock(return_value=False)),
+            patch("custom_components.autosnooze.coordinator._log_command") as mock_log_command,
+            pytest.raises(ServiceValidationError),
+        ):
+            await async_cancel_scheduled_batch(mock_hass, data, ["automation.test"])
+
+        mock_log_command.assert_called_once_with("cancel_scheduled", "error", ANY)
 
 
 # =============================================================================

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -2,6 +2,26 @@
 
 from __future__ import annotations
 
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("latency_ms", "expected"),
+    [
+        (0.0, "lt_10ms"),
+        (9.999, "lt_10ms"),
+        (10.0, "lt_100ms"),
+        (99.999, "lt_100ms"),
+        (100.0, "lt_1000ms"),
+        (999.999, "lt_1000ms"),
+        (1000.0, "gte_1000ms"),
+    ],
+)
+def test_latency_bucket_boundaries(latency_ms: float, expected: str) -> None:
+    from custom_components.autosnooze.logging_utils import _latency_bucket
+
+    assert _latency_bucket(latency_ms) == expected
+
 
 def test_latency_bucket_less_than_10ms() -> None:
     from custom_components.autosnooze.logging_utils import _latency_bucket
@@ -23,19 +43,36 @@ def test_latency_bucket_less_than_1000ms() -> None:
 
 def test_log_command_emits_structured_fields(caplog) -> None:
     import logging
-    from time import perf_counter
+    from unittest.mock import patch
 
     from custom_components.autosnooze.logging_utils import _log_command
 
     caplog.set_level(logging.INFO, logger="custom_components.autosnooze.logging_utils")
-    started_at = perf_counter()
-    _log_command("pause", "success", started_at)
+    with patch("custom_components.autosnooze.logging_utils.perf_counter", return_value=25.05):
+        _log_command("pause", "success", 25.0, operation_id="op-123")
 
     record = next(r for r in caplog.records if r.message == "autosnooze_command")
     assert record.command == "pause"
     assert record.outcome == "success"
+    assert record.operation_id == "op-123"
+    assert record.latency_bucket == "lt_100ms"
+
+
+def test_log_command_default_operation_id_and_bucket_boundary(caplog) -> None:
+    import logging
+    from unittest.mock import patch
+
+    from custom_components.autosnooze.logging_utils import _log_command
+
+    caplog.set_level(logging.INFO, logger="custom_components.autosnooze.logging_utils")
+    with patch("custom_components.autosnooze.logging_utils.perf_counter", return_value=26.0):
+        _log_command("resume", "failed", 25.0005)
+
+    record = next(r for r in caplog.records if r.message == "autosnooze_command")
     assert record.operation_id == "n/a"
-    assert record.latency_bucket in {"lt_10ms", "lt_100ms", "lt_1000ms", "gte_1000ms"}
+    assert record.command == "resume"
+    assert record.outcome == "failed"
+    assert record.latency_bucket == "lt_1000ms"
 
 
 def test_raise_save_failed_raises_with_correct_translation_key() -> None:
@@ -46,4 +83,6 @@ def test_raise_save_failed_raises_with_correct_translation_key() -> None:
 
     with pytest.raises(ServiceValidationError) as exc_info:
         _raise_save_failed()
+    assert str(exc_info.value) == "Failed to persist autosnooze state"
+    assert exc_info.value.translation_domain == "autosnooze"
     assert exc_info.value.translation_key == "save_failed"

--- a/tests/test_models_coverage.py
+++ b/tests/test_models_coverage.py
@@ -6,7 +6,9 @@ These tests focus on edge cases and branches not covered by existing tests.
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock
+import os
+import time
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -74,7 +76,7 @@ class TestEnsureUtcAware:
         result = ensure_utc_aware(None)
         assert result is None
 
-    def test_naive_datetime_treated_as_local_converted_to_utc(self) -> None:
+    def test_naive_datetime_treated_as_local_converted_to_utc(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that naive datetime is treated as local time and converted to UTC.
 
         DEF-013 FIX: Naive datetimes are now assumed to be in local timezone,
@@ -83,17 +85,41 @@ class TestEnsureUtcAware:
         naive_dt = datetime(2024, 6, 15, 12, 0, 0)
         assert naive_dt.tzinfo is None
 
-        result = ensure_utc_aware(naive_dt)
+        original_tz = os.environ.get("TZ")
+        try:
+            with patch(
+                "custom_components.autosnooze.models.dt_util.get_default_time_zone",
+                return_value=timezone(timedelta(hours=2)),
+            ):
+                monkeypatch.setenv("TZ", "America/Chicago")
+                time.tzset()
+                result = ensure_utc_aware(naive_dt)
+        finally:
+            if original_tz is None:
+                monkeypatch.delenv("TZ", raising=False)
+            else:
+                monkeypatch.setenv("TZ", original_tz)
+            time.tzset()
 
         assert result is not None
         assert result.tzinfo == UTC
-        # The hour may differ from 12 depending on local timezone offset
+        assert result == datetime(2024, 6, 15, 10, 0, 0, tzinfo=UTC)
 
-    def test_utc_aware_datetime_returned_as_utc(self) -> None:
+    def test_utc_aware_datetime_returned_as_utc(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that UTC-aware datetime is returned as UTC."""
+        original_tz = os.environ.get("TZ")
         aware_dt = datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC)
 
-        result = ensure_utc_aware(aware_dt)
+        try:
+            monkeypatch.setenv("TZ", "America/Chicago")
+            time.tzset()
+            result = ensure_utc_aware(aware_dt)
+        finally:
+            if original_tz is None:
+                monkeypatch.delenv("TZ", raising=False)
+            else:
+                monkeypatch.setenv("TZ", original_tz)
+            time.tzset()
 
         assert result.tzinfo == UTC
         assert result.hour == 12  # UTC stays the same

--- a/tests/test_sensor_coverage.py
+++ b/tests/test_sensor_coverage.py
@@ -6,16 +6,18 @@ These tests focus on the sensor platform and AutoSnoozeCountSensor class.
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from custom_components.autosnooze.const import DOMAIN, SIGNAL_STATE_CHANGED, VERSION
 from custom_components.autosnooze.models import (
     PausedAutomation,
     ScheduledSnooze,
 )
 from custom_components.autosnooze.runtime.state import AutomationPauseData
 from custom_components.autosnooze.sensor import AutoSnoozeCountSensor
+from homeassistant.helpers.device_registry import DeviceEntryType
 
 UTC = timezone.utc
 
@@ -59,9 +61,10 @@ class TestAutoSnoozeCountSensor:
         """Test sensor device info."""
         device_info = sensor._attr_device_info
         assert device_info is not None
-        assert "identifiers" in device_info
-        assert "name" in device_info
+        assert device_info["identifiers"] == {(DOMAIN, sensor._entry.entry_id)}
         assert device_info["name"] == "AutoSnooze"
+        assert device_info["entry_type"] == DeviceEntryType.SERVICE
+        assert device_info["sw_version"] == VERSION
 
     def test_native_value_returns_zero_when_empty(
         self, sensor: AutoSnoozeCountSensor, data: AutomationPauseData
@@ -135,6 +138,32 @@ class TestAutoSnoozeCountSensor:
 
         # Triggering notify should call async_write_ha_state
         data.notify()
+        sensor.async_write_ha_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_async_added_to_hass_uses_dispatcher_when_hass_is_available(
+        self, sensor: AutoSnoozeCountSensor
+    ) -> None:
+        """Test Home Assistant lifecycle wiring uses dispatcher updates."""
+        hass = MagicMock()
+        unsub = MagicMock()
+        sensor.hass = hass
+        sensor.async_write_ha_state = MagicMock()
+
+        with patch(
+            "custom_components.autosnooze.sensor.async_dispatcher_connect",
+            return_value=unsub,
+        ) as connect:
+            await sensor.async_added_to_hass()
+
+        connect.assert_called_once()
+        called_hass, signal, update = connect.call_args.args
+        assert called_hass is hass
+        assert signal == SIGNAL_STATE_CHANGED
+        assert callable(update)
+        assert sensor._unsub is unsub
+
+        update()
         sensor.async_write_ha_state.assert_called_once()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add architecture contracts and backend mutation runner coverage
- bump jscpd to 4.2.0 and expose backend mutation script
- strengthen backend/coordinator coverage for mutation-sensitive behavior

## Verification
- PYTHONPATH=/Users/matt/Desktop/Projects/autodoctor/venv_test/lib/python3.14/site-packages /Users/matt/Desktop/Projects/autodoctor/venv_test/bin/pytest tests/test_coordinator.py::TestAsyncSave tests/test_coordinator.py::TestAsyncCancelScheduled tests/test_coordinator.py::TestAsyncCancelScheduledBatch ci_contracts -q
- prior full coordinator mutation sweep on ajax/mess: killed: 548, survived: 0, crashed: 0