### PR TITLE
Tighten mobile snooze layout

### DIFF
--- a/custom_components/autosnooze/www/autosnooze-card.js
+++ b/custom_components/autosnooze/www/autosnooze-card.js
@@ -267,7 +267,7 @@ function e(e,t,a,o){var i,s=arguments.length,r=s<3?t:null===o?o=Object.getOwnPro
         box-shadow: 0 4px 14px color-mix(in srgb, var(--primary-color) 25%, transparent),
                     0 2px 4px rgba(0, 0, 0, 0.1);
         transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-        margin-top: 6px;
+        margin-top: 0;
         touch-action: manipulation;
         -webkit-tap-highlight-color: transparent;
       }
@@ -1142,7 +1142,7 @@ function e(e,t,a,o){var i,s=arguments.length,r=s<3?t:null===o?o=Object.getOwnPro
 
       .duration-pills {
         gap: 8px;
-        margin-bottom: 12px;
+        margin-bottom: 6px;
       }
 
       .pill {
@@ -1241,11 +1241,11 @@ function e(e,t,a,o){var i,s=arguments.length,r=s<3?t:null===o?o=Object.getOwnPro
       }
 
       .schedule-link {
-        margin-top: 14px;
-        padding: 10px 6px;
+        margin-top: 6px;
+        padding: 6px 4px;
         font-size: 0.85em;
         font-weight: 500;
-        min-height: 44px;
+        min-height: 36px;
         opacity: 0.8;
         transition: opacity 0.15s ease;
       }
@@ -1901,7 +1901,7 @@ function e(e,t,a,o){var i,s=arguments.length,r=s<3?t:null===o?o=Object.getOwnPro
 
       /* --- Selection List: Card-style items with depth --- */
       .selection-list {
-        max-height: min(200px, 35dvh);
+        max-height: min(252px, calc(35dvh + 52px));
         margin-bottom: 16px;
         border-radius: 12px;
         border: 1.5px solid color-mix(in srgb, var(--divider-color) 60%, transparent);

--- a/src/styles/automation-list.styles.ts
+++ b/src/styles/automation-list.styles.ts
@@ -468,7 +468,7 @@ export const automationListStyles = css`
 
       /* --- Selection List: Card-style items with depth --- */
       .selection-list {
-        max-height: min(200px, 35dvh);
+        max-height: min(252px, calc(35dvh + 52px));
         margin-bottom: 16px;
         border-radius: 12px;
         border: 1.5px solid color-mix(in srgb, var(--divider-color) 60%, transparent);

--- a/src/styles/card.styles.ts
+++ b/src/styles/card.styles.ts
@@ -274,7 +274,7 @@ export const cardStyles = css`
         box-shadow: 0 4px 14px color-mix(in srgb, var(--primary-color) 25%, transparent),
                     0 2px 4px rgba(0, 0, 0, 0.1);
         transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-        margin-top: 6px;
+        margin-top: 0;
         touch-action: manipulation;
         -webkit-tap-highlight-color: transparent;
       }

--- a/src/styles/duration-selector.styles.ts
+++ b/src/styles/duration-selector.styles.ts
@@ -273,7 +273,7 @@ export const durationSelectorStyles = css`
 
       .duration-pills {
         gap: 8px;
-        margin-bottom: 12px;
+        margin-bottom: 6px;
       }
 
       .pill {
@@ -372,11 +372,11 @@ export const durationSelectorStyles = css`
       }
 
       .schedule-link {
-        margin-top: 14px;
-        padding: 10px 6px;
+        margin-top: 6px;
+        padding: 6px 4px;
         font-size: 0.85em;
         font-weight: 500;
-        min-height: 44px;
+        min-height: 36px;
         opacity: 0.8;
         transition: opacity 0.15s ease;
       }

--- a/src/tests/mobile-layout-shrink.spec.ts
+++ b/src/tests/mobile-layout-shrink.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+import { automationListStyles } from '../styles/automation-list.styles.js';
+import { cardStyles } from '../styles/card.styles.js';
+import { durationSelectorStyles } from '../styles/duration-selector.styles.js';
+
+function cssBlock(cssText: string, selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const matches = Array.from(cssText.matchAll(new RegExp(`${escapedSelector}\\s*\\{[^}]*\\}`, 'g')));
+  expect(matches, `Missing CSS block for ${selector}`).not.toHaveLength(0);
+  return matches[matches.length - 1][0];
+}
+
+function declarationValue(block: string, property: string): string {
+  const escapedProperty = property.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = block.match(new RegExp(`${escapedProperty}:\\s*([^;]+);`));
+  expect(match, `Missing ${property} declaration in ${block}`).not.toBeNull();
+  return match![1].trim();
+}
+
+describe('Mobile layout compactness', () => {
+  test('duration controls leave less vertical space before the snooze button on mobile', () => {
+    const cssText = durationSelectorStyles.cssText;
+
+    expect(cssText).toContain('@media (max-width: 480px)');
+    expect(declarationValue(cssBlock(cssText, '.duration-pills'), 'margin-bottom')).toBe('6px');
+    expect(declarationValue(cssBlock(cssText, '.schedule-link'), 'margin-top')).toBe('6px');
+    expect(declarationValue(cssBlock(cssText, '.schedule-link'), 'padding')).toBe('6px 4px');
+    expect(declarationValue(cssBlock(cssText, '.schedule-link'), 'min-height')).toBe('36px');
+  });
+
+  test('mobile snooze button does not add extra top spacing', () => {
+    const cssText = cardStyles.cssText;
+
+    expect(cssText).toContain('@media (max-width: 480px)');
+    expect(declarationValue(cssBlock(cssText, '.snooze-btn'), 'margin-top')).toBe('0');
+  });
+
+  test('mobile automation list keeps adaptive sizing with one extra row', () => {
+    const cssText = automationListStyles.cssText;
+
+    expect(cssText).not.toContain('@media (max-width: 480px) and (orientation: portrait)');
+    expect(declarationValue(cssBlock(cssText, '.selection-list'), 'max-height')).toBe('min(252px, calc(35dvh + 52px))');
+    expect(cssText).toContain('-webkit-overflow-scrolling: touch');
+    expect(cssText).toContain('overscroll-behavior: contain');
+  });
+});


### PR DESCRIPTION
## Summary
- shrink mobile spacing between duration controls, date/time option, and the snooze button
- keep the automations list adaptive on mobile while allowing one additional row
- add a focused mobile layout style regression spec
- update the built Lovelace card artifact

## Tests
- npm run test -- src/tests/mobile-layout-shrink.spec.ts src/tests/search-row-layout.spec.ts src/tests/search-row-polish.spec.ts src/tests/autosnooze-automation-list.spec.ts tests/test_duration_selector.spec.ts tests/test_card_ui.spec.ts
- npm run typecheck:test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized mobile button spacing, duration selector layout, and selection list height constraints for improved screen utilization on smaller devices.

* **Tests**
  * Added mobile layout compactness validation tests to ensure responsive design consistency across smaller screen sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mossipcams/autosnooze/pull/386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->