### PR TITLE
Skip Husky hooks for Release Please artifact refresh

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -74,6 +74,7 @@ jobs:
         id: artifact
         env:
           BRANCH_NAME: ${{ steps.pr.outputs.branch }}
+          HUSKY: '0'
         run: |
           if git diff --quiet -- custom_components/autosnooze/www/autosnooze-card.js custom_components/autosnooze/www/autosnooze-card.js.map; then
             echo "Generated artifact already up to date."

--- a/src/tests/release-please-workflow.spec.ts
+++ b/src/tests/release-please-workflow.spec.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+const WORKFLOW_PATH = join(process.cwd(), '.github', 'workflows', 'release-please.yml');
+
+function workflowSource(): string {
+  return readFileSync(WORKFLOW_PATH, 'utf8');
+}
+
+function stepBlock(source: string, stepName: string): string {
+  const start = source.indexOf(`- name: ${stepName}`);
+  expect(start, `Missing workflow step: ${stepName}`).toBeGreaterThanOrEqual(0);
+
+  const rest = source.slice(start + 1);
+  const nextStep = rest.search(/\n\s+- name: /);
+  return nextStep === -1 ? source.slice(start) : source.slice(start, start + 1 + nextStep);
+}
+
+describe('Release Please workflow', () => {
+  test('artifact refresh bot push does not run local Husky hooks', () => {
+    const commitStep = stepBlock(workflowSource(), 'Commit refreshed generated card artifact');
+
+    expect(commitStep).toContain('HUSKY:');
+    expect(commitStep).toMatch(/HUSKY:\s*['"]?0['"]?/);
+    expect(commitStep).toContain('git commit -m "build: refresh generated card artifact for release PR"');
+    expect(commitStep).toContain('git push origin "HEAD:$BRANCH_NAME"');
+  });
+});


### PR DESCRIPTION
## Summary
- disable Husky only for the Release Please artifact-refresh commit/push step
- add a workflow regression spec that guards against rerunning local Husky hooks in that bot push path

## Why
The post-merge Release Please workflow failed after refreshing generated card artifacts because the bot push invoked Husky, which ran the pre-push critical E2E hook without Playwright browsers installed on the runner.

## Tests
- npm run test -- src/tests/release-please-workflow.spec.ts
- npm run typecheck:test
- npm run lint -- .github/workflows/release-please.yml src/tests/release-please-workflow.spec.ts