### PR TITLE
ci: keep Husky local-only

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -74,7 +74,6 @@ jobs:
         id: artifact
         env:
           BRANCH_NAME: ${{ steps.pr.outputs.branch }}
-          HUSKY: '0'
         run: |
           if git diff --quiet -- custom_components/autosnooze/www/autosnooze-card.js custom_components/autosnooze/www/autosnooze-card.js.map; then
             echo "Generated artifact already up to date."

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint:unused:prod": "knip --config knip.production.json --reporter compact --production",
     "typecheck": "tsc --noEmit",
     "typecheck:test": "tsc --noEmit -p tsconfig.test.json",
-    "prepare": "husky || true",
+    "prepare": "node scripts/install-husky-if-local.mjs",
     "mutation:backend": "python3 scripts/run_backend_mutation.py"
   },
   "keywords": [

--- a/scripts/install-husky-if-local.mjs
+++ b/scripts/install-husky-if-local.mjs
@@ -1,0 +1,19 @@
+import husky from 'husky';
+
+const ci = process.env.CI === 'true' || process.env.CI === '1';
+const huskyDisabled = process.env.HUSKY === '0' || process.env.HUSKY === 'false';
+
+if (ci || huskyDisabled) {
+  console.log('Skipping Husky install outside local developer environment.');
+  process.exit(0);
+}
+
+try {
+  const message = husky();
+  if (message) {
+    console.log(message);
+  }
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.warn(`Unable to install Husky hooks: ${message}`);
+}

--- a/src/tests/husky-local-only.spec.ts
+++ b/src/tests/husky-local-only.spec.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+const PACKAGE_PATH = join(process.cwd(), 'package.json');
+
+function packageJson(): { scripts?: Record<string, string> } {
+  return JSON.parse(readFileSync(PACKAGE_PATH, 'utf8')) as { scripts?: Record<string, string> };
+}
+
+describe('Husky install contract', () => {
+  test('prepare keeps Husky local-only instead of installing hooks in CI', () => {
+    const prepare = packageJson().scripts?.prepare ?? '';
+
+    expect(prepare).toContain('install-husky-if-local');
+    expect(prepare).not.toMatch(/^husky\b/);
+  });
+});

--- a/src/tests/release-please-workflow.spec.ts
+++ b/src/tests/release-please-workflow.spec.ts
@@ -18,12 +18,16 @@ function stepBlock(source: string, stepName: string): string {
 }
 
 describe('Release Please workflow', () => {
-  test('artifact refresh bot push does not run local Husky hooks', () => {
-    const commitStep = stepBlock(workflowSource(), 'Commit refreshed generated card artifact');
+  test('artifact refresh bot pushes rely on package-level local-only Husky installs', () => {
+    const source = workflowSource();
+    const commitStep = stepBlock(source, 'Commit refreshed generated card artifact');
+    const syncedCommitStep = stepBlock(source, 'Commit synced generated card artifact');
 
-    expect(commitStep).toContain('HUSKY:');
-    expect(commitStep).toMatch(/HUSKY:\s*['"]?0['"]?/);
+    expect(commitStep).not.toContain('HUSKY:');
+    expect(syncedCommitStep).not.toContain('HUSKY:');
     expect(commitStep).toContain('git commit -m "build: refresh generated card artifact for release PR"');
     expect(commitStep).toContain('git push origin "HEAD:$BRANCH_NAME"');
+    expect(syncedCommitStep).toContain('git commit -m "build: refresh generated card artifact for synced release PR"');
+    expect(syncedCommitStep).toContain('git push origin "HEAD:$BRANCH_NAME"');
   });
 });


### PR DESCRIPTION
## Summary
- make package prepare skip Husky installation in CI/non-local automation
- add a root-cause contract test for local-only Husky installs
- remove the release workflow's per-step Husky workaround

## Tests
- npm test -- src/tests/husky-local-only.spec.ts
- npm test -- src/tests/release-please-workflow.spec.ts
- npm test -- src/tests/husky-local-only.spec.ts src/tests/release-please-workflow.spec.ts
- npm run typecheck:test
- npx eslint src/tests/husky-local-only.spec.ts src/tests/release-please-workflow.spec.ts
- CI=true npm run prepare
- HUSKY=0 npm run prepare

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Husky hooks now install only in local development environments, not during CI runs
  * Release automation workflow steps updated for improved artifact handling

* **Tests**
  * Added verification for local-only Husky installation behavior
  * Enhanced release workflow test coverage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mossipcams/autosnooze/pull/388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->