### PR TITLE
fix(ci): sync release PR build status on workflow_dispatch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -167,7 +167,10 @@ jobs:
 
   sync-existing-release-pr:
     needs: release-please
-    if: ${{ github.event_name == 'push' && needs.release-please.outputs.prs_created != 'true' }}
+    # Bot pushes to the release PR branch do not re-trigger pull_request Build workflows,
+    # so keep the open Release Please PR synced and mirror a successful Build check.
+    # workflow_dispatch must run this path too; only refresh-release-pr-artifacts handles brand-new PRs.
+    if: ${{ needs.release-please.result == 'success' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && needs.release-please.outputs.prs_created != 'true')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Summary
Release Please PRs only get a mirrored `build` check from `sync-existing-release-pr`. That job was limited to `push` events, so manual `workflow_dispatch` runs (and recovery flows) left PR #399 without an updated Build status.

## Changes
- Run `sync-existing-release-pr` on `workflow_dispatch` as well as on `push` when no new release PR was created.

## Test plan
- [ ] Merge this PR
- [ ] Re-run Release Please on `main` or push to `main`
- [ ] Confirm open release PR shows green `build` check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to support manual triggering in addition to automatic deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->