### PR TITLE
refactor: remove coordinator validate_stored_* passthrough wrappers

### DIFF
--- a/custom_components/autosnooze/coordinator.py
+++ b/custom_components/autosnooze/coordinator.py
@@ -6,7 +6,7 @@ import asyncio
 from datetime import datetime, timedelta
 import logging
 from time import perf_counter
-from typing import Any, Literal
+from typing import Literal
 
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME
 from homeassistant.exceptions import ServiceValidationError
@@ -36,8 +36,6 @@ from .runtime.state import AutomationPauseData
 from .runtime.restore import (
     async_load_stored as runtime_async_load_stored,
     configure_default_restore_callbacks,
-    validate_stored_data as runtime_validate_stored_data,
-    validate_stored_entry as runtime_validate_stored_entry,
 )
 from .runtime.timers import (
     cancel_notification_timer as runtime_cancel_notification_timer,
@@ -694,32 +692,6 @@ async def async_save(data: AutomationPauseData) -> bool:
         True if save succeeded, False if all retries exhausted.
     """
     return await infrastructure_async_save(data, sleep=asyncio.sleep)
-
-
-def validate_stored_entry(
-    entity_id: str,
-    entry_data: Any,
-    entry_type: str,
-) -> bool:
-    """Validate a single stored entry.
-
-    Args:
-        entity_id: The entity ID (key in storage)
-        entry_data: The entry data
-        entry_type: "paused" or "scheduled"
-
-    Returns:
-        True if valid, False if invalid.
-    """
-    return runtime_validate_stored_entry(entity_id, entry_data, entry_type)
-
-
-def validate_stored_data(stored: Any) -> dict[str, Any]:
-    """Validate and sanitize stored data.
-
-    Returns validated data with invalid entries removed.
-    """
-    return runtime_validate_stored_data(stored)
 
 
 async def async_load_stored(hass: HomeAssistant, data: AutomationPauseData) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -32,6 +32,8 @@ from custom_components.autosnooze.coordinator import (
     get_friendly_name,
     schedule_disable,
     schedule_resume,
+)
+from custom_components.autosnooze.runtime.restore import (
     validate_stored_data,
     validate_stored_entry,
 )

--- a/tests/test_notify_on_resume_contract.py
+++ b/tests/test_notify_on_resume_contract.py
@@ -8,7 +8,7 @@ import pytest
 import voluptuous as vol
 
 from custom_components.autosnooze.const import PAUSE_SCHEMA
-from custom_components.autosnooze.coordinator import validate_stored_data
+from custom_components.autosnooze.runtime.restore import validate_stored_data
 from custom_components.autosnooze.models import PausedAutomation, ScheduledSnooze
 
 UTC = timezone.utc

--- a/tests/test_validation_edge_cases.py
+++ b/tests/test_validation_edge_cases.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from custom_components.autosnooze.coordinator import (
+from custom_components.autosnooze.runtime.restore import (
     validate_stored_data,
     validate_stored_entry,
 )


### PR DESCRIPTION
## What

`coordinator.validate_stored_entry` and `coordinator.validate_stored_data` were thin **passthrough wrappers** around the identical functions in `runtime/restore.py` — which holds the real validation logic and is what the live restore path actually calls. No production code imported the coordinator wrappers.

## One spaghetti pattern

Dead coordinator passthrough wrappers superseded by the runtime layer (same family as #420).

| Budget rule | This PR |
|---|---|
| One spaghetti pattern | ✅ dead coordinator passthrough wrappers |
| Net production LOC decreases | ✅ **−28** |
| No new abstractions/files | ✅ deletion only |
| No public API/behavior change | ✅ identical logic remains in `runtime/restore.py`; wrappers not imported by production |
| Tests focused on public behavior | ✅ tests repointed to the real implementation, no assertion change |

**Total: 4 files, +5 / −31.**

## Changes

- **Production:** delete the two wrappers from `coordinator.py` and their now-unused imports (`typing.Any`, the two `runtime_validate_*` aliases).
- **Tests:** repoint `test_validation_edge_cases.py`, `test_coordinator.py`, and `test_notify_on_resume_contract.py` validate imports from `coordinator` to `runtime.restore`. The functions are identical, so this is an import source change only — no assertions touched.

## Verification

- `.venv` backend suite: **587 passed** — identical to baseline, proving no coverage lost (validation now exercised directly against `runtime.restore`).
- `ruff check custom_components/autosnooze/` and the touched test files — clean.

Note: backend-only change; the pre-push frontend e2e visual gate is unrelated.