### PR TITLE
fix(ci): include refactors in release notes

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -2,6 +2,20 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-component-in-tag": false,
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "refactor",
+      "section": "Refactoring"
+    }
+  ],
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",

--- a/ci_contracts/test_release_please_contract.py
+++ b/ci_contracts/test_release_please_contract.py
@@ -1,0 +1,18 @@
+"""Release Please configuration contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATH = ROOT / ".github" / "release-please-config.json"
+
+
+def test_refactor_commits_are_included_in_release_notes() -> None:
+    """Ensure refactor-only cleanup PRs remain visible in release notes."""
+    config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    sections = config["changelog-sections"]
+
+    assert {"type": "refactor", "section": "Refactoring"} in sections


### PR DESCRIPTION
## Summary
- include `refactor:` commits in Release Please changelogs
- add a CI contract preventing cleanup PRs from disappearing from release notes
- verified replacement tech-debt code from #414, #420, #421, and #422 is present on main

## Verification
- `pytest ci_contracts/test_release_please_contract.py -q`
- JSON validation and `git diff --check`

Local pre-push critical E2E could not serve `/autosnooze-card.js` and returned 404; repository CI will verify the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release notes configuration to properly categorize and include refactoring improvements.

* **Tests**
  * Added validation to ensure refactoring changes are included in generated release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->