### PR TITLE
chore(deps): align Home Assistant test fixture

### DIFF
--- a/ci_contracts/test_python_dependencies_contract.py
+++ b/ci_contracts/test_python_dependencies_contract.py
@@ -14,7 +14,7 @@ def test_pytest_homeassistant_custom_component_tracks_current_fixture() -> None:
     """Keep the Home Assistant test fixture on the reviewed patch release."""
     requirements = REQUIREMENTS_TEST_PATH.read_text(encoding="utf-8")
 
-    assert "pytest-homeassistant-custom-component>=0.13.342,<0.13.343" in requirements
+    assert "pytest-homeassistant-custom-component>=0.13.345,<0.13.346" in requirements
 
 
 def test_pytest_matches_homeassistant_2026_5_fixture_dependency() -> None:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,7 +3,7 @@
 
 pytest==9.0.3
 pytest-asyncio==1.4.0
-pytest-homeassistant-custom-component>=0.13.342,<0.13.343
+pytest-homeassistant-custom-component>=0.13.345,<0.13.346
 pytest-cov==7.1.0
 
 # Linting and formatting (ruff handles both)


### PR DESCRIPTION
## Summary
- update pytest-homeassistant-custom-component to the 0.13.345 patch range
- keep pytest pinned to 9.0.3 because pytest-homeassistant-custom-component 0.13.345 still requires pytest==9.0.3
- update the Python dependency contract to match the reviewed fixture package range

## Verification
- python3 -m pytest ci_contracts/test_python_dependencies_contract.py -q
- python3 -m venv /tmp/autosnooze-deps-check && /tmp/autosnooze-deps-check/bin/python -m pip install -r requirements_test.txt
- TZ=UTC /tmp/autosnooze-deps-check/bin/python -m pytest -q tests/test_smoke.py
- /tmp/autosnooze-deps-check/bin/python -m pytest ci_contracts -q
- TZ=UTC /tmp/autosnooze-deps-check/bin/python -m pytest tests/ -q

Supersedes #464. Leaves #463 blocked because the current Home Assistant fixture package pins pytest==9.0.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a test dependency to a newer compatible version.
  * Kept the project aligned with the latest supported test tooling for improved maintenance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->