### PR TITLE
chore(deps): bump HA fixture and fix Dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
       prefix: "chore(deps)"
     labels:
       - "dependencies"
-      - "javascript"
     groups:
       npm-minor-patch:
         patterns:
@@ -31,7 +30,6 @@ updates:
       prefix: "chore(deps)"
     labels:
       - "dependencies"
-      - "python"
     groups:
       pip-minor-patch:
         patterns:

--- a/ci_contracts/test_dependabot_contract.py
+++ b/ci_contracts/test_dependabot_contract.py
@@ -1,0 +1,19 @@
+"""Dependabot configuration contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPENDABOT_PATH = ROOT / ".github" / "dependabot.yml"
+
+
+def test_dependabot_only_uses_labels_that_exist_on_the_repo() -> None:
+    """Keep Dependabot from commenting that configured labels are missing."""
+    config = DEPENDABOT_PATH.read_text(encoding="utf-8")
+
+    assert '- "javascript"' not in config
+    assert '- "python"' not in config
+    assert '- "dependencies"' in config
+    assert '- "github-actions"' in config

--- a/ci_contracts/test_frontend_resource_boundary_contract.py
+++ b/ci_contracts/test_frontend_resource_boundary_contract.py
@@ -100,7 +100,8 @@ def test_existing_python_contract_surface_stays_compatible() -> None:
     """Frontend hardening should be tested at the adapter, not copied into the root."""
     adapter_source = FRONTEND_ADAPTER_PATH.read_text(encoding="utf-8")
 
-    assert "StaticPathConfig" in adapter_source
+    assert "from homeassistant.components.http.server import StaticPathConfig" in adapter_source
+    assert "from homeassistant.components.http import StaticPathConfig" not in adapter_source
     assert "cache_headers=False" in adapter_source
     assert "for url in (CARD_URL, CARD_HACS_URL)" not in adapter_source
     assert "[StaticPathConfig(CARD_URL, str(CARD_PATH), cache_headers=False)]" in adapter_source

--- a/ci_contracts/test_python_dependencies_contract.py
+++ b/ci_contracts/test_python_dependencies_contract.py
@@ -14,7 +14,7 @@ def test_pytest_homeassistant_custom_component_tracks_current_fixture() -> None:
     """Keep the Home Assistant test fixture on the reviewed patch release."""
     requirements = REQUIREMENTS_TEST_PATH.read_text(encoding="utf-8")
 
-    assert "pytest-homeassistant-custom-component>=0.13.345,<0.13.346" in requirements
+    assert "pytest-homeassistant-custom-component>=0.13.346,<0.13.347" in requirements
 
 
 def test_pytest_matches_homeassistant_2026_5_fixture_dependency() -> None:

--- a/ci_contracts/test_python_dependencies_contract.py
+++ b/ci_contracts/test_python_dependencies_contract.py
@@ -14,7 +14,7 @@ def test_pytest_homeassistant_custom_component_tracks_current_fixture() -> None:
     """Keep the Home Assistant test fixture on the reviewed patch release."""
     requirements = REQUIREMENTS_TEST_PATH.read_text(encoding="utf-8")
 
-    assert "pytest-homeassistant-custom-component>=0.13.346,<0.13.347" in requirements
+    assert "pytest-homeassistant-custom-component>=0.13.355,<0.13.356" in requirements
 
 
 def test_pytest_matches_homeassistant_2026_5_fixture_dependency() -> None:

--- a/custom_components/autosnooze/infrastructure/frontend.py
+++ b/custom_components/autosnooze/infrastructure/frontend.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from homeassistant.components.http import StaticPathConfig
+from homeassistant.components.http.server import StaticPathConfig
 from homeassistant.core import HomeAssistant
 
 from ..const import CARD_PATH, CARD_URL, CARD_URL_VERSIONED, VERSION

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,7 +3,7 @@
 
 pytest==9.0.3
 pytest-asyncio==1.4.0
-pytest-homeassistant-custom-component>=0.13.345,<0.13.346
+pytest-homeassistant-custom-component>=0.13.346,<0.13.347
 pytest-cov==7.1.0
 
 # Linting and formatting (ruff handles both)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,7 +3,7 @@
 
 pytest==9.0.3
 pytest-asyncio==1.4.0
-pytest-homeassistant-custom-component>=0.13.346,<0.13.347
+pytest-homeassistant-custom-component>=0.13.355,<0.13.356
 pytest-cov==7.1.0
 
 # Linting and formatting (ruff handles both)


### PR DESCRIPTION
## Summary
- bump `pytest-homeassistant-custom-component` to `>=0.13.355,<0.13.356`
- keep `pytest==9.0.3` (fixture still requires it)
- update the Python dependency contract to match
- drop non-existent Dependabot labels (`javascript`, `python`); keep `dependencies` / `github-actions`

Supersedes #473. Closed as blocked: #472 (pytest pin), #476 (Node 22), #477 (TS ESLint peers), #480 (knip / Node).

## Test plan
- [x] `pytest ci_contracts/test_python_dependencies_contract.py -q`
- [x] `pytest ci_contracts/test_dependabot_contract.py -q`
- [x] pip install from `requirements_test.txt` in a clean venv
- [x] `TZ=UTC pytest -q tests/test_smoke.py`
- [ ] CI build workflow