### PR TITLE
chore(deps): bump actions/setup-python from 6.3.0 to 7.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
 
       - name: Setup Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.14'
           cache: 'pip'
@@ -62,7 +62,7 @@ jobs:
 
       # === Python Setup ===
       - name: Setup Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.14'
           cache: 'pip'


### PR DESCRIPTION
## Summary
- bump `actions/setup-python` from 6.3.0 (`ece7cb06…`) to 7.0.0 (`5fda3b95…`)
- fix stale `# v5` pin comments to `# v7.0.0`

Replaces closed Dependabot #492 (merge blocked by OAuth `workflow` scope on that token path; this lands the same change).

## Test plan
- [ ] CI `build` / `smoke-backend` green
- [ ] Workflow validation green