### PR TITLE
test: add public TelemetryDeck privacy verification CI

### DIFF
--- a/.github/workflows/telemetry-privacy.yml
+++ b/.github/workflows/telemetry-privacy.yml
@@ -15,7 +15,6 @@ on:
       - 'package.json'
       - 'package-lock.json'
   pull_request:
-    branches: [main]
     paths:
       - '.github/workflows/telemetry-privacy.yml'
       - 'custom_components/autosnooze/infrastructure/telemetry.py'

--- a/.github/workflows/telemetry-privacy.yml
+++ b/.github/workflows/telemetry-privacy.yml
@@ -1,0 +1,76 @@
+name: Telemetry Privacy Verification
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/telemetry-privacy.yml'
+      - 'custom_components/autosnooze/infrastructure/telemetry.py'
+      - 'custom_components/autosnooze/application/report_telemetry.py'
+      - 'docs/telemetry-payloads.json'
+      - 'docs/telemetry-privacy.md'
+      - 'tests/telemetry-privacy.spec.ts'
+      - 'tests/helpers/telemetry_privacy_capture.py'
+      - 'requirements_test.txt'
+      - 'package.json'
+      - 'package-lock.json'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/telemetry-privacy.yml'
+      - 'custom_components/autosnooze/infrastructure/telemetry.py'
+      - 'custom_components/autosnooze/application/report_telemetry.py'
+      - 'docs/telemetry-payloads.json'
+      - 'docs/telemetry-privacy.md'
+      - 'tests/telemetry-privacy.spec.ts'
+      - 'tests/helpers/telemetry_privacy_capture.py'
+      - 'requirements_test.txt'
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  telemetry-privacy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: 'requirements_test.txt'
+
+      - name: Install Python dependencies
+        run: pip install -r requirements_test.txt
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Run telemetry privacy verification
+        run: npx vitest run tests/telemetry-privacy.spec.ts
+
+      - name: Upload captured payload golden
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: telemetry-payloads
+          path: docs/telemetry-payloads.json
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Events are explicit and property-scoped. Shared properties on applicable events:
 
 Telemetry is **on by default**. Turn it off in **Settings → Devices & Services → AutoSnooze → Configure → Send anonymous usage data**.
 
+AutoSnooze's telemetry payloads are verified in public CI. The test executes every instrumented action using deliberately identifiable Home Assistant data, captures the actual TelemetryDeck requests, and fails if any private or undocumented data is transmitted. [View verification](docs/telemetry-privacy.md)
+
 ### Example payload
 
 Signals are posted as a JSON array to TelemetryDeck. A `snooze_created` event looks like this:

--- a/docs/telemetry-payloads.json
+++ b/docs/telemetry-payloads.json
@@ -1,0 +1,114 @@
+{
+  "card_viewed": {
+    "autosnooze_version": "0.2.27",
+    "card_type": "full",
+    "event_schema_version": "1",
+    "home_assistant_version": "2024.1.0-test",
+    "source": "card"
+  },
+  "confirmation_result": {
+    "autosnooze_version": "0.2.27",
+    "event_schema_version": "1",
+    "home_assistant_version": "2024.1.0-test",
+    "result": "confirmed",
+    "source": "card"
+  },
+  "duration_option_selected": {
+    "autosnooze_version": "0.2.27",
+    "event_schema_version": "1",
+    "home_assistant_version": "2024.1.0-test",
+    "method": "preset",
+    "source": "card"
+  },
+  "integration_active": {
+    "autosnooze_version": "0.2.27",
+    "event_schema_version": "1",
+    "home_assistant_version": "2024.1.0-test",
+    "source": "startup"
+  },
+  "notification_cleared": {
+    "autosnooze_version": "0.2.27",
+    "event_schema_version": "1",
+    "home_assistant_version": "2024.1.0-test",
+    "source": "service",
+    "target_count": "1"
+  },
+  "notification_used": {
+    "autosnooze_version": "0.2.27",
+    "event_schema_version": "1",
+    "home_assistant_version": "2024.1.0-test",
+    "source": "card",
+    "trigger": "start"
+  },
+  "operation_failed": {
+    "autosnooze_version": "0.2.27",
+    "error_code": "unknown",
+    "event_schema_version": "1",
+    "home_assistant_version": "2024.1.0-test",
+    "operation": "pause_automations",
+    "source": "service",
+    "strategy": "duration",
+    "target_count": "1"
+  },
+  "scheduled_snooze_cancelled": {
+    "autosnooze_version": "0.2.27",
+    "event_schema_version": "1",
+    "home_assistant_version": "2024.1.0-test",
+    "minutes_before_start": "30",
+    "source": "service",
+    "target_count": "1"
+  },
+  "scheduled_snooze_created": {
+    "autosnooze_version": "0.2.27",
+    "event_schema_version": "1",
+    "home_assistant_version": "2024.1.0-test",
+    "minutes_until_start": "60",
+    "planned_duration_minutes": "120",
+    "resume_local_hour": "7",
+    "source": "service",
+    "target_count": "2"
+  },
+  "scheduled_snooze_started": {
+    "autosnooze_version": "0.2.27",
+    "event_schema_version": "1",
+    "home_assistant_version": "2024.1.0-test",
+    "planned_duration_minutes": "120",
+    "source": "timer",
+    "target_count": "2"
+  },
+  "selection_feature_used": {
+    "autosnooze_version": "0.2.27",
+    "event_schema_version": "1",
+    "home_assistant_version": "2024.1.0-test",
+    "method": "all",
+    "source": "card"
+  },
+  "snooze_adjusted": {
+    "autosnooze_version": "0.2.27",
+    "delta_minutes": "15",
+    "direction": "extend",
+    "event_schema_version": "1",
+    "home_assistant_version": "2024.1.0-test",
+    "source": "card"
+  },
+  "snooze_created": {
+    "autosnooze_version": "0.2.27",
+    "confirmation_used": "false",
+    "duration_minutes": "30",
+    "event_schema_version": "1",
+    "home_assistant_version": "2024.1.0-test",
+    "input_method": "card",
+    "notification_lead_minutes": "0",
+    "notification_trigger": "none",
+    "source": "card",
+    "strategy": "duration",
+    "target_count": "1"
+  },
+  "snooze_ended": {
+    "autosnooze_version": "0.2.27",
+    "event_schema_version": "1",
+    "home_assistant_version": "2024.1.0-test",
+    "reason": "expired",
+    "source": "timer"
+  }
+}

--- a/docs/telemetry-privacy.md
+++ b/docs/telemetry-privacy.md
@@ -51,9 +51,9 @@ CI compares live capture output to this file with strict equality.
 
 The harness injects these canary values into attempted properties and HA-like fields. None may appear in captured JSON.
 
-- `automation.matt_private_bedroom`
-- `Matt's Private Bedroom`
-- `matt@example.com`
+- `automation.guest_private_bedroom`
+- `Guest's Private Bedroom`
+- `guest@example.com`
 - `https://private-home.example.com`
 - `192.168.1.45`
 - `private-user-id-12345`

--- a/docs/telemetry-privacy.md
+++ b/docs/telemetry-privacy.md
@@ -1,0 +1,79 @@
+# AutoSnooze Telemetry Privacy Verification
+
+[![Telemetry Privacy Verification](https://github.com/mossipcams/autosnooze/actions/workflows/telemetry-privacy.yml/badge.svg)](https://github.com/mossipcams/autosnooze/actions/workflows/telemetry-privacy.yml)
+
+This check runs on every push to `main` and on pull requests. It drives the real Python `TelemetryClient`, seeds deliberately identifiable Home Assistant data, intercepts outbound TelemetryDeck requests, and fails on any private or undocumented field.
+
+## Collected fields
+
+TelemetryDeck envelope keys per request batch item:
+
+- `appID`
+- `clientUser` (SHA-256 hash of a per-install UUID, never the raw install ID)
+- `type` (event name)
+- `payload` (sanitized property object)
+
+Shared `payload` keys on every event:
+
+- `autosnooze_version`
+- `home_assistant_version`
+- `event_schema_version`
+- `source` (`card`, `service`, `timer`, or `startup`)
+
+Event-specific `payload` keys:
+
+| Event | Properties |
+|-------|------------|
+| `integration_active` | versions and source only |
+| `card_viewed` | `card_type` |
+| `selection_feature_used` | `method` |
+| `duration_option_selected` | `method` |
+| `snooze_created` | `strategy`, `input_method`, `duration_minutes`, `target_count`, `notification_trigger`, `notification_lead_minutes`, `confirmation_used` |
+| `scheduled_snooze_created` | `minutes_until_start`, `planned_duration_minutes`, `target_count`, `resume_local_hour` |
+| `scheduled_snooze_started` | `target_count`, `planned_duration_minutes` |
+| `snooze_adjusted` | `delta_minutes`, `direction` |
+| `snooze_ended` | `reason` |
+| `scheduled_snooze_cancelled` | `target_count`, `minutes_before_start` |
+| `notification_used` | `trigger` |
+| `notification_cleared` | `target_count` |
+| `operation_failed` | `operation`, `error_code`, `strategy`, `target_count` |
+| `confirmation_result` | `result` |
+
+## Captured payloads
+
+The committed golden file lists the exact `payload` object for each of the 14 events after sanitization:
+
+- [telemetry-payloads.json](./telemetry-payloads.json)
+
+CI compares live capture output to this file with strict equality.
+
+## Seeded test data
+
+The harness injects these canary values into attempted properties and HA-like fields. None may appear in captured JSON.
+
+- `automation.matt_private_bedroom`
+- `Matt's Private Bedroom`
+- `matt@example.com`
+- `https://private-home.example.com`
+- `192.168.1.45`
+- `private-user-id-12345`
+- `private-config-entry-67890`
+
+These Home Assistant field names are also forbidden inside `payload`:
+
+- `entity_id`, `friendly_name`, `user_id`, `config_entry_id`, `area_id`, `device_id`, `latitude`, `longitude`, `install_id`, `clientUser`
+
+## Test source
+
+- [tests/telemetry-privacy.spec.ts](../tests/telemetry-privacy.spec.ts)
+
+The Vitest spec spawns the Python capture helper, which calls `TelemetryClient.track` and `report_telemetry` while mocking `async_get_clientsession` / `session.post`.
+
+## Reproduce locally
+
+```bash
+python3 -m venv .venv
+.venv/bin/pip install -r requirements_test.txt
+npm ci
+npx vitest run tests/telemetry-privacy.spec.ts
+```

--- a/tests/helpers/telemetry_privacy_capture.py
+++ b/tests/helpers/telemetry_privacy_capture.py
@@ -28,9 +28,9 @@ FIXED_HA_VERSION = "2024.1.0-test"
 FIXED_INSTALL_ID = "privacy-test-install-id"
 
 CANARY_STRINGS = [
-    "automation.matt_private_bedroom",
-    "Matt's Private Bedroom",
-    "matt@example.com",
+    "automation.guest_private_bedroom",
+    "Guest's Private Bedroom",
+    "guest@example.com",
     "https://private-home.example.com",
     "192.168.1.45",
     "private-user-id-12345",
@@ -38,8 +38,8 @@ CANARY_STRINGS = [
 ]
 
 CANARY_PROPERTIES: dict[str, Any] = {
-    "entity_id": "automation.matt_private_bedroom",
-    "friendly_name": "Matt's Private Bedroom",
+    "entity_id": "automation.guest_private_bedroom",
+    "friendly_name": "Guest's Private Bedroom",
     "user_id": "private-user-id-12345",
     "config_entry_id": "private-config-entry-67890",
     "area_id": "private-bedroom-area",
@@ -48,7 +48,7 @@ CANARY_PROPERTIES: dict[str, Any] = {
     "longitude": "-122.4194",
     "install_id": "private-install-leak",
     "clientUser": "private-client-user-leak",
-    "user_email": "matt@example.com",
+    "user_email": "guest@example.com",
     "ha_url": "https://private-home.example.com",
     "ip_address": "192.168.1.45",
 }

--- a/tests/helpers/telemetry_privacy_capture.py
+++ b/tests/helpers/telemetry_privacy_capture.py
@@ -1,0 +1,360 @@
+"""Drive TelemetryClient and capture outbound TelemetryDeck payloads for privacy CI."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from custom_components.autosnooze.application.report_telemetry import (  # noqa: E402
+    async_handle_report_telemetry,
+)
+from custom_components.autosnooze.infrastructure.telemetry import (  # noqa: E402
+    EVENT_SCHEMAS,
+    TELEMETRY_INGEST_URL,
+    TelemetryClient,
+)
+from custom_components.autosnooze.runtime.state import AutomationPauseData  # noqa: E402
+
+FIXED_AUTOSNOOZE_VERSION = "0.2.27"
+FIXED_HA_VERSION = "2024.1.0-test"
+FIXED_INSTALL_ID = "privacy-test-install-id"
+
+CANARY_STRINGS = [
+    "automation.matt_private_bedroom",
+    "Matt's Private Bedroom",
+    "matt@example.com",
+    "https://private-home.example.com",
+    "192.168.1.45",
+    "private-user-id-12345",
+    "private-config-entry-67890",
+]
+
+CANARY_PROPERTIES: dict[str, Any] = {
+    "entity_id": "automation.matt_private_bedroom",
+    "friendly_name": "Matt's Private Bedroom",
+    "user_id": "private-user-id-12345",
+    "config_entry_id": "private-config-entry-67890",
+    "area_id": "private-bedroom-area",
+    "device_id": "private-bedroom-device",
+    "latitude": "37.7749",
+    "longitude": "-122.4194",
+    "install_id": "private-install-leak",
+    "clientUser": "private-client-user-leak",
+    "user_email": "matt@example.com",
+    "ha_url": "https://private-home.example.com",
+    "ip_address": "192.168.1.45",
+}
+
+FORBIDDEN_PAYLOAD_FIELDS = frozenset(
+    {
+        "entity_id",
+        "friendly_name",
+        "user_id",
+        "config_entry_id",
+        "area_id",
+        "device_id",
+        "latitude",
+        "longitude",
+        "install_id",
+        "clientUser",
+    }
+)
+
+STANDARD_PAYLOAD_KEYS = frozenset(
+    {
+        "autosnooze_version",
+        "home_assistant_version",
+        "event_schema_version",
+        "source",
+    }
+)
+
+CARD_REPORT_EVENTS: dict[str, dict[str, Any]] = {
+    "card_viewed": {"properties": {}, "source": "card", "card_type": "full"},
+    "selection_feature_used": {"properties": {"method": "all"}, "source": "card"},
+    "duration_option_selected": {"properties": {"method": "preset"}, "source": "card"},
+    "confirmation_result": {"properties": {"result": "confirmed"}, "source": "card"},
+    "snooze_created": {
+        "properties": {
+            "strategy": "duration",
+            "input_method": "card",
+            "duration_minutes": 30,
+            "target_count": 1,
+            "notification_trigger": "none",
+            "notification_lead_minutes": 0,
+            "confirmation_used": False,
+        },
+        "source": "card",
+    },
+}
+
+TRACK_EVENTS: dict[str, dict[str, Any]] = {
+    "integration_active": {"properties": {}, "source": "startup"},
+    "scheduled_snooze_created": {
+        "properties": {
+            "minutes_until_start": 60,
+            "planned_duration_minutes": 120,
+            "target_count": 2,
+            "resume_local_hour": 7,
+        },
+        "source": "service",
+    },
+    "scheduled_snooze_started": {
+        "properties": {"target_count": 2, "planned_duration_minutes": 120},
+        "source": "timer",
+    },
+    "snooze_adjusted": {
+        "properties": {"delta_minutes": 15, "direction": "extend"},
+        "source": "card",
+    },
+    "snooze_ended": {"properties": {"reason": "expired"}, "source": "timer"},
+    "scheduled_snooze_cancelled": {
+        "properties": {"target_count": 1, "minutes_before_start": 30},
+        "source": "service",
+    },
+    "notification_used": {"properties": {"trigger": "start"}, "source": "card"},
+    "notification_cleared": {"properties": {"target_count": 1}, "source": "service"},
+    "operation_failed": {
+        "properties": {
+            "operation": "pause_automations",
+            "error_code": "unknown",
+            "strategy": "duration",
+            "target_count": 1,
+        },
+        "source": "service",
+    },
+}
+
+
+def _polluted_properties(base: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    merged.update(CANARY_PROPERTIES)
+    return merged
+
+
+def _allowed_payload_keys(event: str) -> frozenset[str]:
+    return STANDARD_PAYLOAD_KEYS | EVENT_SCHEMAS[event]
+
+
+def _scan_payload(event: str, payload: dict[str, Any]) -> tuple[list[str], list[str]]:
+    undocumented: list[str] = []
+    forbidden: list[str] = []
+    allowed = _allowed_payload_keys(event)
+    if event == "card_viewed":
+        allowed = allowed | {"card_type"}
+    for key in payload:
+        if key not in allowed:
+            undocumented.append(f"{event}.{key}")
+        if key in FORBIDDEN_PAYLOAD_FIELDS:
+            forbidden.append(f"{event}.{key}")
+    return undocumented, forbidden
+
+
+def _scan_canaries(text: str) -> list[str]:
+    return [canary for canary in CANARY_STRINGS if canary in text]
+
+
+def _make_post_mock(captured_posts: list[dict[str, Any]]) -> MagicMock:
+    def mock_post(url: str, *, json: list[dict[str, Any]], timeout: float) -> MagicMock:
+        captured_posts.append({"url": url, "json": json})
+        response = MagicMock()
+        response.status = 200
+        response.__aenter__ = AsyncMock(return_value=response)
+        response.__aexit__ = AsyncMock(return_value=None)
+        return response
+
+    session = MagicMock()
+    session.post = MagicMock(side_effect=mock_post)
+    return session
+
+
+async def _build_client(*, enabled: bool) -> tuple[TelemetryClient, list[dict[str, Any]]]:
+    captured_posts: list[dict[str, Any]] = []
+    hass = MagicMock()
+    hass.async_create_task = MagicMock()
+    entry = MagicMock()
+    entry.options = {"telemetry_enabled": enabled}
+    store = MagicMock()
+    store.async_load = AsyncMock(return_value={"install_id": FIXED_INSTALL_ID, "last_card_viewed_day": None})
+    store.async_save = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "custom_components.autosnooze.infrastructure.telemetry.async_get_clientsession",
+            return_value=_make_post_mock(captured_posts),
+        ),
+        patch(
+            "custom_components.autosnooze.infrastructure.telemetry.VERSION",
+            FIXED_AUTOSNOOZE_VERSION,
+        ),
+        patch(
+            "custom_components.autosnooze.infrastructure.telemetry._ha_version",
+            return_value=FIXED_HA_VERSION,
+        ),
+    ):
+        client = TelemetryClient(hass, entry, store)
+        await client.async_setup()
+        client._last_card_viewed_day = None
+        return client, captured_posts
+
+
+async def _flush_posts(client: TelemetryClient, captured_posts: list[dict[str, Any]]) -> None:
+    with (
+        patch(
+            "custom_components.autosnooze.infrastructure.telemetry.async_get_clientsession",
+            return_value=_make_post_mock(captured_posts),
+        ),
+        patch(
+            "custom_components.autosnooze.infrastructure.telemetry.VERSION",
+            FIXED_AUTOSNOOZE_VERSION,
+        ),
+        patch(
+            "custom_components.autosnooze.infrastructure.telemetry._ha_version",
+            return_value=FIXED_HA_VERSION,
+        ),
+    ):
+        await client.async_flush()
+
+
+async def _exercise_report_telemetry(
+    client: TelemetryClient,
+    hass: MagicMock,
+    event: str,
+    spec: dict[str, Any],
+) -> None:
+    data = AutomationPauseData(telemetry=client, hass=hass)
+    call = MagicMock()
+    call.data = {
+        "event": event,
+        "properties": _polluted_properties(spec.get("properties", {})),
+        "source": spec["source"],
+    }
+    card_type = spec.get("card_type")
+    if card_type is not None:
+        call.data["card_type"] = card_type
+        call.data["friendly_name"] = CANARY_PROPERTIES["friendly_name"]
+    await async_handle_report_telemetry(hass, data, call)
+
+
+async def capture() -> dict[str, Any]:
+    payloads: dict[str, dict[str, str]] = {}
+    captured_posts: list[dict[str, Any]] = []
+    undocumented_fields: list[str] = []
+    forbidden_fields: list[str] = []
+    canary_hits: list[str] = []
+
+    client, captured_posts = await _build_client(enabled=True)
+    hass = client.hass
+
+    with (
+        patch(
+            "custom_components.autosnooze.infrastructure.telemetry.VERSION",
+            FIXED_AUTOSNOOZE_VERSION,
+        ),
+        patch(
+            "custom_components.autosnooze.infrastructure.telemetry._ha_version",
+            return_value=FIXED_HA_VERSION,
+        ),
+    ):
+        for event, spec in CARD_REPORT_EVENTS.items():
+            await _exercise_report_telemetry(client, hass, event, spec)
+            await _flush_posts(client, captured_posts)
+
+        for event, spec in TRACK_EVENTS.items():
+            polluted = _polluted_properties(spec.get("properties", {}))
+            client.track(
+                event,
+                polluted,
+                source=spec["source"],
+                card_type=spec.get("card_type"),
+            )
+            await _flush_posts(client, captured_posts)
+
+    disabled_posts: list[dict[str, Any]] = []
+    disabled_client, disabled_posts = await _build_client(enabled=False)
+    disabled_client.entry.options = {"telemetry_enabled": False}
+    disabled_hass = disabled_client.hass
+
+    with (
+        patch(
+            "custom_components.autosnooze.infrastructure.telemetry.VERSION",
+            FIXED_AUTOSNOOZE_VERSION,
+        ),
+        patch(
+            "custom_components.autosnooze.infrastructure.telemetry._ha_version",
+            return_value=FIXED_HA_VERSION,
+        ),
+    ):
+        for event, spec in CARD_REPORT_EVENTS.items():
+            await _exercise_report_telemetry(disabled_client, disabled_hass, event, spec)
+            await _flush_posts(disabled_client, disabled_posts)
+        for event, spec in TRACK_EVENTS.items():
+            disabled_client.track(
+                event,
+                _polluted_properties(spec.get("properties", {})),
+                source=spec["source"],
+                card_type=spec.get("card_type"),
+            )
+            await _flush_posts(disabled_client, disabled_posts)
+
+    for post in captured_posts:
+        assert post["url"] == TELEMETRY_INGEST_URL
+        for signal in post["json"]:
+            event = signal["type"]
+            payload = signal["payload"]
+            payloads[event] = payload
+            event_undocumented, event_forbidden = _scan_payload(event, payload)
+            undocumented_fields.extend(event_undocumented)
+            forbidden_fields.extend(event_forbidden)
+            canary_hits.extend(_scan_canaries(json.dumps(payload)))
+            assert "clientUser" not in payload
+            assert signal.get("clientUser")
+
+    events_exercised = len(CARD_REPORT_EVENTS) + len(TRACK_EVENTS)
+
+    return {
+        "payloads": payloads,
+        "meta": {
+            "events_exercised": events_exercised,
+            "outbound_requests": len(captured_posts),
+            "telemetry_requests_while_disabled": len(disabled_posts),
+            "undocumented_fields": len(undocumented_fields),
+            "forbidden_ha_fields": len(forbidden_fields),
+            "canary_hits": sorted(set(canary_hits)),
+            "undocumented_field_names": sorted(set(undocumented_fields)),
+            "forbidden_field_names": sorted(set(forbidden_fields)),
+            "autosnooze_version": FIXED_AUTOSNOOZE_VERSION,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--write-golden",
+        type=Path,
+        help="Write payload map to docs/telemetry-payloads.json",
+    )
+    args = parser.parse_args()
+    result = asyncio.run(capture())
+    if args.write_golden:
+        args.write_golden.parent.mkdir(parents=True, exist_ok=True)
+        args.write_golden.write_text(
+            json.dumps(result["payloads"], indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    json.dump(result, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/telemetry-privacy.spec.ts
+++ b/tests/telemetry-privacy.spec.ts
@@ -9,9 +9,9 @@ const GOLDEN_PATH = join(REPO_ROOT, 'docs', 'telemetry-payloads.json');
 const CAPTURE_SCRIPT = join(REPO_ROOT, 'tests', 'helpers', 'telemetry_privacy_capture.py');
 
 const CANARY_STRINGS = [
-  'automation.matt_private_bedroom',
-  "Matt's Private Bedroom",
-  'matt@example.com',
+  'automation.guest_private_bedroom',
+  "Guest's Private Bedroom",
+  'guest@example.com',
   'https://private-home.example.com',
   '192.168.1.45',
   'private-user-id-12345',
@@ -126,6 +126,7 @@ describe('telemetry privacy verification', () => {
       const documentedPayload = documented[event];
       expect(actualPayload).toEqual(documentedPayload);
       const serialized = JSON.stringify(actualPayload);
+      expect(serialized).not.toContain('guest_private_bedroom');
       for (const canary of CANARY_STRINGS) {
         expect(serialized).not.toContain(canary);
       }

--- a/tests/telemetry-privacy.spec.ts
+++ b/tests/telemetry-privacy.spec.ts
@@ -1,0 +1,141 @@
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+const REPO_ROOT = join(__dirname, '..');
+const GOLDEN_PATH = join(REPO_ROOT, 'docs', 'telemetry-payloads.json');
+const CAPTURE_SCRIPT = join(REPO_ROOT, 'tests', 'helpers', 'telemetry_privacy_capture.py');
+
+const CANARY_STRINGS = [
+  'automation.matt_private_bedroom',
+  "Matt's Private Bedroom",
+  'matt@example.com',
+  'https://private-home.example.com',
+  '192.168.1.45',
+  'private-user-id-12345',
+  'private-config-entry-67890',
+] as const;
+
+const FORBIDDEN_PAYLOAD_FIELDS = [
+  'entity_id',
+  'friendly_name',
+  'user_id',
+  'config_entry_id',
+  'area_id',
+  'device_id',
+  'latitude',
+  'longitude',
+  'install_id',
+  'clientUser',
+] as const;
+
+type CaptureMeta = {
+  autosnooze_version: string;
+  canary_hits: string[];
+  events_exercised: number;
+  forbidden_field_names: string[];
+  forbidden_ha_fields: number;
+  outbound_requests: number;
+  telemetry_requests_while_disabled: number;
+  undocumented_field_names: string[];
+  undocumented_fields: number;
+};
+
+type CaptureResult = {
+  meta: CaptureMeta;
+  payloads: Record<string, Record<string, string>>;
+};
+
+function resolvePython(): string {
+  const venvPython = join(REPO_ROOT, '.venv', 'bin', 'python');
+  return existsSync(venvPython) ? venvPython : 'python3';
+}
+
+function runCapture(): CaptureResult {
+  const stdout = execFileSync(resolvePython(), [CAPTURE_SCRIPT], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return JSON.parse(stdout) as CaptureResult;
+}
+
+function shortCommitSha(): string {
+  try {
+    return execFileSync('git', ['rev-parse', '--short', 'HEAD'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+function buildReport(meta: CaptureMeta): string {
+  const passed =
+    meta.events_exercised === 14 &&
+    meta.outbound_requests === 14 &&
+    meta.undocumented_fields === 0 &&
+    meta.forbidden_ha_fields === 0 &&
+    meta.telemetry_requests_while_disabled === 0 &&
+    meta.canary_hits.length === 0;
+
+  return [
+    'AutoSnooze Telemetry Privacy Verification',
+    `Commit: ${shortCommitSha()}`,
+    `AutoSnooze version: ${meta.autosnooze_version}`,
+    'Telemetry events exercised: 14/14',
+    `Outbound requests captured: ${meta.outbound_requests}`,
+    `Undocumented fields found: ${meta.undocumented_fields}`,
+    `Private canary values found: ${meta.canary_hits.length}`,
+    `Forbidden Home Assistant fields found: ${meta.forbidden_ha_fields}`,
+    `Telemetry requests while disabled: ${meta.telemetry_requests_while_disabled}`,
+    `RESULT: ${passed ? 'PASSED' : 'FAILED'}`,
+    '',
+  ].join('\n');
+}
+
+function publishReport(report: string): void {
+  process.stdout.write(`${report}\n`);
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    appendFileSync(summaryPath, `${report}\n`);
+  }
+}
+
+describe('telemetry privacy verification', () => {
+  const capture = runCapture();
+  const documented = JSON.parse(readFileSync(GOLDEN_PATH, 'utf8')) as Record<
+    string,
+    Record<string, string>
+  >;
+
+  test('exercises all telemetry events and matches documented payloads', () => {
+    expect(capture.meta.events_exercised).toBe(14);
+    expect(capture.meta.outbound_requests).toBe(14);
+    expect(capture.meta.telemetry_requests_while_disabled).toBe(0);
+    expect(capture.meta.undocumented_fields).toBe(0);
+    expect(capture.meta.forbidden_ha_fields).toBe(0);
+    expect(capture.meta.canary_hits).toEqual([]);
+
+    expect(Object.keys(capture.payloads).sort()).toEqual(Object.keys(documented).sort());
+
+    for (const [event, actualPayload] of Object.entries(capture.payloads)) {
+      const documentedPayload = documented[event];
+      expect(actualPayload).toEqual(documentedPayload);
+      const serialized = JSON.stringify(actualPayload);
+      for (const canary of CANARY_STRINGS) {
+        expect(serialized).not.toContain(canary);
+      }
+      for (const forbiddenField of FORBIDDEN_PAYLOAD_FIELDS) {
+        expect(actualPayload).not.toHaveProperty(forbiddenField);
+      }
+    }
+
+    const report = buildReport(capture.meta);
+    publishReport(report);
+    expect(report).toContain('RESULT: PASSED');
+  });
+});


### PR DESCRIPTION
## What

Public CI that loads AutoSnooze telemetry with seeded private canaries, intercepts TelemetryDeck POSTs, and fails on undocumented fields or leaked HA data. Ships the verification page, golden payloads, vitest gate, and workflow badge.

Stacked on #494.

## Why

Zod and allowlists reduce leak risk. A publicly passing capture report is what users can link instead of trusting docs alone.

## Verify

```bash
python3 -m venv .venv && .venv/bin/pip install -r requirements_test.txt
npm ci
npx vitest run tests/telemetry-privacy.spec.ts
```

Report shape matches `docs/telemetry-privacy.md`.