### PR TITLE
ci: test HA 2026.7 floor and keep 0.x feat as minor

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -21,7 +21,7 @@
       "changelog-path": "CHANGELOG.md",
       "release-type": "node",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": false,
       "extra-files": [
         {
           "type": "json",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,8 @@ jobs:
         include:
           - ha: "2026.8.1"
             fixture: "pytest-homeassistant-custom-component==0.13.355"
-          - ha: "2026.7.4"
-            fixture: "pytest-homeassistant-custom-component==0.13.348"
+          - ha: "2026.6.0"
+            fixture: "pytest-homeassistant-custom-component==0.13.336"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,17 @@ permissions: {}
 
 jobs:
   smoke-backend:
+    name: smoke-backend (HA ${{ matrix.ha }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ha: "2026.8.1"
+            fixture: "pytest-homeassistant-custom-component==0.13.355"
+          - ha: "2026.7.4"
+            fixture: "pytest-homeassistant-custom-component==0.13.348"
 
     steps:
       - name: Checkout repository
@@ -45,7 +54,13 @@ jobs:
           cache-dependency-path: 'requirements_test.txt'
 
       - name: Install Python dependencies
-        run: pip install -r requirements_test.txt
+        run: |
+          pip install -r requirements_test.txt
+          pip install "${{ matrix.fixture }}"
+
+      - name: Verify Home Assistant version
+        run: |
+          python3 -c "from homeassistant.const import __version__; print(__version__); assert __version__ == '${{ matrix.ha }}', __version__"
 
       - name: Run backend release-gate smoke suite
         run: python3 -m pytest -q tests/test_smoke.py

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,28 @@
+name: PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  validate-title:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: python3 ci_contracts/pr_title_classification.py

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub Stars](https://img.shields.io/github/stars/mossipcams/autosnooze?style=flat-square)](https://github.com/mossipcams/autosnooze/stargazers)
 [![HA Analytics](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fanalytics.home-assistant.io%2Fcustom_integrations.json&query=%24.autosnooze.total&suffix=%20installs&label=Active%20Installs&style=flat-square&color=41BDF5)](https://analytics.home-assistant.io)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/mossipcams/autosnooze/build.yml?branch=main&style=flat-square)](https://github.com/mossipcams/autosnooze/actions)
-[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2024.1+-blue.svg?style=flat-square)](https://www.home-assistant.io/)
+[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2026.7+-blue.svg?style=flat-square)](https://www.home-assistant.io/)
 
 Temporarily pause Home Assistant automations with automatic re-enabling. Snooze an automation, it comes back on its own. No more forgotten disabled automations cluttering your setup.
 
@@ -338,7 +338,7 @@ Make sure AutoSnooze is configured in **Settings → Devices & Services**.
 
 ## Requirements
 
-- Home Assistant **2024.1** or newer
+- Home Assistant **2026.7** or newer
 - Areas and Labels configured (optional, for filtering)
 
 -----

--- a/ci_contracts/pr_title_classification.py
+++ b/ci_contracts/pr_title_classification.py
@@ -1,0 +1,71 @@
+"""Classify conventional-commit PR titles for Release Please bump semantics."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+_ALLOWED_TYPES = frozenset(
+    {
+        "feat",
+        "fix",
+        "refactor",
+        "chore",
+        "docs",
+        "test",
+        "ci",
+        "build",
+        "perf",
+        "style",
+        "revert",
+    }
+)
+_TITLE_RE = re.compile(r"^([a-z]+)(\([^)]+\))?(!)?: (.+)$")
+
+
+def classify(title: str) -> str:
+    """Return bump class for a conventional-commit PR title."""
+    if not title or not title.strip():
+        msg = "PR title must not be empty"
+        raise ValueError(msg)
+
+    first_line = title.split("\n", 1)[0]
+    match = _TITLE_RE.match(first_line)
+    if not match:
+        msg = f"PR title must use conventional commits: {first_line!r}"
+        raise ValueError(msg)
+
+    commit_type, _scope, breaking, _subject = match.groups()
+    if commit_type not in _ALLOWED_TYPES:
+        msg = f"PR title type is not allowed: {commit_type!r}"
+        raise ValueError(msg)
+    if breaking:
+        return "breaking-minor"
+    if commit_type == "fix":
+        return "patch"
+    if commit_type == "feat":
+        return "minor"
+    return "none"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    title = os.environ.get("PR_TITLE")
+    if title is None and args:
+        title = args[0]
+
+    if title is None:
+        print("PR title is required (set PR_TITLE or pass as argument)", file=sys.stderr)
+        return 1
+
+    try:
+        print(classify(title))
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci_contracts/test_pr_title_classification.py
+++ b/ci_contracts/test_pr_title_classification.py
@@ -1,0 +1,67 @@
+"""Contract tests for PR title conventional-commit classification."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from pr_title_classification import classify
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PR_TITLE_WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "pr-title.yml"
+
+
+@pytest.mark.parametrize(
+    ("title", "expected"),
+    [
+        ("fix: accept null optionals", "patch"),
+        ("feat: add telemetry", "minor"),
+        ("feat!: rename pause API", "breaking-minor"),
+        ("feat(card)!: breaking", "breaking-minor"),
+        ("refactor: extract helper", "none"),
+        ("chore(deps): bump foo", "none"),
+        ("docs: fix typo", "none"),
+        ("test: add coverage", "none"),
+        ("ci: test HA floor", "none"),
+        ("chore(main): release 0.2.30", "none"),
+    ],
+)
+def test_classify_valid_titles(title: str, expected: str) -> None:
+    assert classify(title) == expected
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "Fix the import",
+        "",
+        "wip: stuff",
+    ],
+)
+def test_classify_invalid_titles(title: str) -> None:
+    with pytest.raises(ValueError):
+        classify(title)
+
+
+def test_pr_title_workflow_exists_and_validates_titles() -> None:
+    """PR title workflow must run the classifier on pull_request events."""
+    assert PR_TITLE_WORKFLOW_PATH.exists(), "pr-title workflow is missing"
+
+    content = PR_TITLE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    required_snippets = [
+        "pull_request:",
+        "opened",
+        "edited",
+        "synchronize",
+        "reopened",
+        "PR_TITLE: ${{ github.event.pull_request.title }}",
+        "ci_contracts/pr_title_classification.py",
+    ]
+
+    missing = [snippet for snippet in required_snippets if snippet not in content]
+    assert not missing, f"PR title workflow is missing required snippets: {missing}"

--- a/ci_contracts/test_python_dependencies_contract.py
+++ b/ci_contracts/test_python_dependencies_contract.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 REQUIREMENTS_TEST_PATH = PROJECT_ROOT / "requirements_test.txt"
 BUILD_WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "build.yml"
+HACS_JSON_PATH = PROJECT_ROOT / "hacs.json"
 
 
 def test_pytest_homeassistant_custom_component_tracks_current_fixture() -> None:
@@ -43,3 +45,20 @@ def test_build_workflow_uses_python_3_14_for_homeassistant_2026_5_fixture() -> N
     workflow = BUILD_WORKFLOW_PATH.read_text(encoding="utf-8")
 
     assert "python-version: '3.14" in workflow
+
+
+def test_hacs_declares_homeassistant_2026_7_floor() -> None:
+    """HACS should hide installs on Home Assistant Core older than 2026.7.0."""
+    hacs = json.loads(HACS_JSON_PATH.read_text(encoding="utf-8"))
+
+    assert hacs.get("homeassistant") == "2026.7.0"
+
+
+def test_smoke_backend_tests_ha_floor_and_current() -> None:
+    """Smoke-backend CI should cover the HA floor patch and current release."""
+    workflow = BUILD_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "pytest-homeassistant-custom-component==0.13.348" in workflow
+    assert "pytest-homeassistant-custom-component==0.13.355" in workflow
+    assert "fail-fast: false" in workflow
+    assert "tests/test_smoke.py" in workflow

--- a/ci_contracts/test_python_dependencies_contract.py
+++ b/ci_contracts/test_python_dependencies_contract.py
@@ -58,7 +58,8 @@ def test_smoke_backend_tests_ha_floor_and_current() -> None:
     """Smoke-backend CI should cover the HA floor patch and current release."""
     workflow = BUILD_WORKFLOW_PATH.read_text(encoding="utf-8")
 
-    assert "pytest-homeassistant-custom-component==0.13.348" in workflow
+    assert 'ha: "2026.6.0"' in workflow
+    assert "pytest-homeassistant-custom-component==0.13.336" in workflow
     assert "pytest-homeassistant-custom-component==0.13.355" in workflow
     assert "fail-fast: false" in workflow
     assert "tests/test_smoke.py" in workflow

--- a/ci_contracts/test_release_please_contract.py
+++ b/ci_contracts/test_release_please_contract.py
@@ -16,3 +16,24 @@ def test_refactor_commits_are_included_in_release_notes() -> None:
     sections = config["changelog-sections"]
 
     assert {"type": "refactor", "section": "Refactoring"} in sections
+
+
+def test_pre_1_0_feat_bumps_minor_not_patch() -> None:
+    """feat is minor while <1.0; feat! stays a breaking minor, not a major."""
+    config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    pkg = config["packages"]["."]
+
+    assert pkg["bump-minor-pre-major"] is True
+    assert pkg.get("bump-patch-for-minor-pre-major") is not True
+
+
+def test_non_release_commit_types_are_not_changelog_bump_types() -> None:
+    """chore/docs/test do not get their own release; node release-type keeps docs non-releasable."""
+    config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    section_types = {section["type"] for section in config["changelog-sections"]}
+
+    assert config["release-type"] == "node"
+    assert config["packages"]["."]["release-type"] == "node"
+    assert "chore" not in section_types
+    assert "docs" not in section_types
+    assert "test" not in section_types

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "AutoSnooze",
   "content_in_root": false,
-  "render_readme": true
+  "render_readme": true,
+  "homeassistant": "2026.7.0"
 }


### PR DESCRIPTION
## Summary
- Smoke-backend now runs against Home Assistant **2026.6.0** (`pytest-homeassistant-custom-component==0.13.336`) and **2026.8.1**, with `fail-fast: false`.
- HACS still declares **2026.7.0** as the install floor.
- New `PR Title` workflow classifies conventional-commit titles (`fix:` → patch, `feat:` → minor, `feat!:` → breaking minor while `<1.0`, `refactor:`/`chore:`/`docs:`/`test:`/`ci:` → no release).
- Default-branch merge is **squash only**, so Release Please reads the PR title.

## Test plan
- [ ] `PR Title` check passes on this PR (`ci: …` → no release)
- [ ] `smoke-backend (HA 2026.6.0)` passes (needs the #500 import fallback on Core older than 2026.8)
- [ ] `smoke-backend (HA 2026.8.1)` passes
- [ ] Merge UI offers squash only
- [ ] A later `feat:` squash-merge would bump `0.2.x` → `0.3.0`
- [ ] A `fix:` squash-merge still bumps patch