### PR TITLE
fix: import StaticPathConfig on HA without http.server

### DIFF
--- a/ci_contracts/test_frontend_resource_boundary_contract.py
+++ b/ci_contracts/test_frontend_resource_boundary_contract.py
@@ -110,6 +110,7 @@ def test_static_path_config_import_supports_ha_without_http_server() -> None:
     """HA Core before 2026.8 has no homeassistant.components.http.server (issue #500)."""
     adapter_source = FRONTEND_ADAPTER_PATH.read_text(encoding="utf-8")
 
+    assert "TYPE_CHECKING" in adapter_source
     assert "from homeassistant.components.http.server import StaticPathConfig" in adapter_source
     assert "from homeassistant.components.http import StaticPathConfig" in adapter_source
     assert "except ImportError" in adapter_source

--- a/ci_contracts/test_frontend_resource_boundary_contract.py
+++ b/ci_contracts/test_frontend_resource_boundary_contract.py
@@ -101,10 +101,18 @@ def test_existing_python_contract_surface_stays_compatible() -> None:
     adapter_source = FRONTEND_ADAPTER_PATH.read_text(encoding="utf-8")
 
     assert "from homeassistant.components.http.server import StaticPathConfig" in adapter_source
-    assert "from homeassistant.components.http import StaticPathConfig" not in adapter_source
     assert "cache_headers=False" in adapter_source
     assert "for url in (CARD_URL, CARD_HACS_URL)" not in adapter_source
     assert "[StaticPathConfig(CARD_URL, str(CARD_PATH), cache_headers=False)]" in adapter_source
+
+
+def test_static_path_config_import_supports_ha_without_http_server() -> None:
+    """HA Core before 2026.8 has no homeassistant.components.http.server (issue #500)."""
+    adapter_source = FRONTEND_ADAPTER_PATH.read_text(encoding="utf-8")
+
+    assert "from homeassistant.components.http.server import StaticPathConfig" in adapter_source
+    assert "from homeassistant.components.http import StaticPathConfig" in adapter_source
+    assert "except ImportError" in adapter_source
 
 
 def test_root_does_not_keep_frontend_compatibility_shims() -> None:

--- a/custom_components/autosnooze/infrastructure/frontend.py
+++ b/custom_components/autosnooze/infrastructure/frontend.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import TYPE_CHECKING
 
-try:
+if TYPE_CHECKING:
     from homeassistant.components.http.server import StaticPathConfig
-except ImportError:
-    from homeassistant.components.http import StaticPathConfig
+else:
+    try:
+        from homeassistant.components.http.server import StaticPathConfig
+    except ImportError:
+        from homeassistant.components.http import StaticPathConfig
 
 from homeassistant.core import HomeAssistant
 

--- a/custom_components/autosnooze/infrastructure/frontend.py
+++ b/custom_components/autosnooze/infrastructure/frontend.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from homeassistant.components.http.server import StaticPathConfig
+try:
+    from homeassistant.components.http.server import StaticPathConfig
+except ImportError:
+    from homeassistant.components.http import StaticPathConfig
+
 from homeassistant.core import HomeAssistant
 
 from ..const import CARD_PATH, CARD_URL, CARD_URL_VERSIONED, VERSION


### PR DESCRIPTION
## Summary
- Import `StaticPathConfig` from `homeassistant.components.http.server` with a fallback to `homeassistant.components.http` so AutoSnooze loads on Home Assistant Core 2026.6/2026.7.
- `http.server` exists for 2026.8 typing; those cores still re-export `StaticPathConfig` from `http` at runtime. 0.2.29 imported `http.server` only and failed to start (`ModuleNotFoundError`).
- Contract `test_static_path_config_import_supports_ha_without_http_server` requires both import paths and `except ImportError`.

Closes #500.

## Test plan
- [ ] Integration starts on HA 2026.7.4 (reporter’s version)
- [ ] Integration starts on HA 2026.6.0
- [ ] Integration still starts on HA 2026.8.1
- [ ] After squash-merge, Release Please opens a patch (`0.2.29` → `0.2.30`)