### PR TITLE
fix(hacs): stop hiding updates from Home Assistant before 2026.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub Stars](https://img.shields.io/github/stars/mossipcams/autosnooze?style=flat-square)](https://github.com/mossipcams/autosnooze/stargazers)
 [![HA Analytics](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fanalytics.home-assistant.io%2Fcustom_integrations.json&query=%24.autosnooze.total&suffix=%20installs&label=Active%20Installs&style=flat-square&color=41BDF5)](https://analytics.home-assistant.io)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/mossipcams/autosnooze/build.yml?branch=main&style=flat-square)](https://github.com/mossipcams/autosnooze/actions)
-[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2026.7+-blue.svg?style=flat-square)](https://www.home-assistant.io/)
+[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2026.6+-blue.svg?style=flat-square)](https://www.home-assistant.io/)
 
 Temporarily pause Home Assistant automations with automatic re-enabling. Snooze an automation, it comes back on its own. No more forgotten disabled automations cluttering your setup.
 
@@ -338,7 +338,7 @@ Make sure AutoSnooze is configured in **Settings → Devices & Services**.
 
 ## Requirements
 
-- Home Assistant **2026.7** or newer
+- Home Assistant **2026.6** or newer
 - Areas and Labels configured (optional, for filtering)
 
 -----

--- a/ci_contracts/test_python_dependencies_contract.py
+++ b/ci_contracts/test_python_dependencies_contract.py
@@ -47,11 +47,11 @@ def test_build_workflow_uses_python_3_14_for_homeassistant_2026_5_fixture() -> N
     assert "python-version: '3.14" in workflow
 
 
-def test_hacs_declares_homeassistant_2026_7_floor() -> None:
-    """HACS should hide installs on Home Assistant Core older than 2026.7.0."""
+def test_hacs_has_no_homeassistant_version_floor() -> None:
+    """HACS should not gate installs on a Home Assistant Core minimum (v0.2.29 had no key)."""
     hacs = json.loads(HACS_JSON_PATH.read_text(encoding="utf-8"))
 
-    assert hacs.get("homeassistant") == "2026.7.0"
+    assert "homeassistant" not in hacs
 
 
 def test_smoke_backend_tests_ha_floor_and_current() -> None:

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,5 @@
 {
   "name": "AutoSnooze",
   "content_in_root": false,
-  "render_readme": true,
-  "homeassistant": "2026.7.0"
+  "render_readme": true
 }


### PR DESCRIPTION
## Summary
- Remove the `homeassistant: 2026.7.0` gate from `hacs.json`. v0.2.29 had no floor; CI still smoke-tests HA 2026.6.0, so HACS was skipping 0.3.0 for older cores.
- Keep the contract: HACS must not declare a Core minimum.
- README now matches the tested floor (2026.6+).

This needs a **0.3.1** GitHub release after merge so HACS offers a new version. Recutting 0.3.0 will not prompt existing installs.

## Test plan
- [x] `python3 -m pytest -q ci_contracts/test_python_dependencies_contract.py` (7 passed)
- [ ] HACS Validation workflow on this PR
- [ ] After 0.3.1 is published, confirm HACS shows an update on HA 2026.6