### PR TITLE
fix: harden runtime recovery paths

### DIFF
--- a/custom_components/autosnooze/application/adjust.py
+++ b/custom_components/autosnooze/application/adjust.py
@@ -38,6 +38,7 @@ async def async_adjust_snooze_batch(
             return
         if not entity_ids:
             return
+        entity_ids = list(dict.fromkeys(entity_ids))
 
         now = dt_util.utcnow()
         updates: list[tuple[str, PausedAutomation, datetime]] = []

--- a/custom_components/autosnooze/application/notifications.py
+++ b/custom_components/autosnooze/application/notifications.py
@@ -117,11 +117,13 @@ async def send_pre_resume_notification(
     hass: HomeAssistant,
     data: AutomationPauseData,
     entity_id: str,
+    expected_pause: PausedAutomation | None = None,
 ) -> None:
     async with data.lock:
         paused = data.paused.get(entity_id)
         if (
             paused is None
+            or (expected_pause is not None and paused is not expected_pause)
             or paused.notification_trigger != NOTIFICATION_TRIGGER_ABOUT_TO_END
             or paused.notification_lead_minutes is None
         ):

--- a/custom_components/autosnooze/application/pause.py
+++ b/custom_components/autosnooze/application/pause.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable, Mapping
 from datetime import datetime, time, timedelta
 import logging
@@ -9,7 +10,7 @@ import re
 from time import perf_counter
 from typing import Any
 
-from homeassistant.const import ATTR_ENTITY_ID, SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET
+from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
@@ -162,6 +163,9 @@ def next_local_time_occurrence(target: time, now_local: datetime | None = None) 
     )
     if candidate <= now:
         candidate += timedelta(days=1)
+    normalized = dt_util.as_utc(candidate).astimezone(candidate.tzinfo)
+    if normalized.replace(tzinfo=None) != candidate.replace(tzinfo=None):
+        candidate += timedelta(days=1)
     return dt_util.as_utc(candidate)
 
 
@@ -244,6 +248,16 @@ async def async_pause_automations(
             hass, data, paused, notification_callback=send_pre_resume_notification
         )
     )
+    cancellation: asyncio.CancelledError | None = None
+
+    async def set_state_safely(entity_id: str, enabled: bool) -> bool:
+        nonlocal cancellation
+        state_change = asyncio.ensure_future(set_state(hass, entity_id, enabled))
+        try:
+            return await asyncio.shield(state_change)
+        except asyncio.CancelledError as err:
+            cancellation = err
+            return await state_change
 
     started_at = perf_counter()
     outcome = "success"
@@ -253,6 +267,7 @@ async def async_pause_automations(
 
         if not entity_ids:
             return
+        entity_ids = list(dict.fromkeys(entity_ids))
 
         for entity_id in entity_ids:
             if not entity_id.startswith("automation."):
@@ -308,6 +323,7 @@ async def async_pause_automations(
 
         scheduled_entries: list[ScheduledSnooze] = []
         paused_entries: list[PausedAutomation] = []
+        initially_enabled: dict[str, bool] = {}
         active_replacements: dict[str, PausedAutomation] = {}
         replacement_wake_results: dict[str, bool] = {}
 
@@ -328,7 +344,11 @@ async def async_pause_automations(
                 )
                 continue
 
-            if not await set_state(hass, entity_id, False):
+            state = hass.states.get(entity_id)
+            initially_enabled[entity_id] = state is not None and state.state == STATE_ON
+            if not await set_state_safely(entity_id, False):
+                if cancellation is not None:
+                    break
                 continue
 
             schedule_mode_disable_at = (
@@ -348,6 +368,14 @@ async def async_pause_automations(
                     notification_lead_minutes=notification_lead_minutes,
                 )
             )
+            if cancellation is not None:
+                break
+
+        if cancellation is not None:
+            for paused in paused_entries:
+                if initially_enabled.get(paused.entity_id) and not await set_state(hass, paused.entity_id, True):
+                    _LOGGER.warning("Failed to restore %s after pause cancellation", paused.entity_id)
+            raise cancellation
 
         if scheduled_entries:
             async with data.lock:
@@ -358,12 +386,20 @@ async def async_pause_automations(
                 }
 
             for entity_id in active_replacements:
-                replacement_wake_results[entity_id] = await set_state(hass, entity_id, True)
+                replacement_wake_results[entity_id] = await set_state_safely(entity_id, True)
                 if not replacement_wake_results[entity_id]:
                     _LOGGER.warning(
                         "Failed to wake %s before replacing active snooze with a future schedule",
                         entity_id,
                     )
+                if cancellation is not None:
+                    break
+
+        if cancellation is not None:
+            for entity_id, woke in replacement_wake_results.items():
+                if woke and not await set_state(hass, entity_id, False):
+                    _LOGGER.warning("Failed to restore %s after scheduled replacement cancellation", entity_id)
+            raise cancellation
 
         re_disable_stale_replacements: list[str] = []
         pre_resume_targets: list[PausedAutomation] = []

--- a/custom_components/autosnooze/application/resume.py
+++ b/custom_components/autosnooze/application/resume.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from time import perf_counter
 from typing import Literal
@@ -39,6 +40,7 @@ async def async_resume(
 
     woke_successfully = await runtime_ports.async_set_automation_state(hass, entity_id, enabled=True)
     re_disable_entity = False
+    retry_scheduled = False
     resumed: list[PausedAutomation] = []
     async with data.lock:
         paused = data.paused.get(entity_id)
@@ -56,13 +58,13 @@ async def async_resume(
             cancel_notification_timer(data, entity_id)
             if paused.resume_retries >= MAX_RESUME_RETRIES:
                 cancel_timer(data, entity_id)
-                data.paused.pop(entity_id, None)
                 _LOGGER.error("Giving up waking %s after %d retries", entity_id, paused.resume_retries)
             else:
                 paused.resume_retries += 1
                 retry_at = dt_util.utcnow() + RESUME_RETRY_DELAY
                 paused.resume_at = retry_at
                 runtime_ports.schedule_resume(hass, data, entity_id, retry_at, resume_callback=async_resume)
+                retry_scheduled = True
     if not await runtime_ports.async_save(data):
         _raise_save_failed()
     if re_disable_entity:
@@ -79,9 +81,7 @@ async def async_resume(
         )
     if woke_successfully:
         _LOGGER.info("Woke automation: %s", entity_id)
-    elif entity_id not in data.paused:
-        pass
-    else:
+    elif retry_scheduled:
         _LOGGER.warning("Failed to wake %s; retry scheduled", entity_id)
 
 
@@ -108,8 +108,23 @@ async def async_resume_batch(
             candidate_ids = list(candidates)
 
         results: dict[str, bool] = {}
+        cancellation: asyncio.CancelledError | None = None
         for entity_id in candidate_ids:
-            results[entity_id] = await runtime_ports.async_set_automation_state(hass, entity_id, enabled=True)
+            state_change = asyncio.ensure_future(
+                runtime_ports.async_set_automation_state(hass, entity_id, enabled=True)
+            )
+            try:
+                results[entity_id] = await asyncio.shield(state_change)
+            except asyncio.CancelledError as err:
+                cancellation = err
+                results[entity_id] = await state_change
+                break
+
+        if cancellation is not None:
+            for entity_id, woke in results.items():
+                if woke and not await runtime_ports.async_set_automation_state(hass, entity_id, enabled=False):
+                    _LOGGER.warning("Failed to restore %s after resume cancellation", entity_id)
+            raise cancellation
 
         failed = 0
         woke = 0
@@ -134,7 +149,6 @@ async def async_resume_batch(
                 else:
                     if paused.resume_retries >= MAX_RESUME_RETRIES:
                         cancel_timer(data, entity_id)
-                        data.paused.pop(entity_id, None)
                         _LOGGER.error("Giving up waking %s after %d retries", entity_id, paused.resume_retries)
                     else:
                         failed += 1

--- a/custom_components/autosnooze/application/scheduled.py
+++ b/custom_components/autosnooze/application/scheduled.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime
 import logging
 from time import perf_counter
 
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, STATE_ON
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.util import dt as dt_util
 
@@ -38,7 +39,26 @@ async def async_execute_scheduled_disable(
         cancel_scheduled_timer(data, entity_id)
         expected_scheduled = data.scheduled.get(entity_id)
 
-    disabled_successfully = await runtime_ports.async_set_automation_state(hass, entity_id, enabled=False)
+    initial_state = hass.states.get(entity_id)
+    was_enabled = initial_state is not None and initial_state.state == STATE_ON
+    cancellation: asyncio.CancelledError | None = None
+    state_change = asyncio.create_task(runtime_ports.async_set_automation_state(hass, entity_id, enabled=False))
+    try:
+        disabled_successfully = await asyncio.shield(state_change)
+    except asyncio.CancelledError as err:
+        cancellation = err
+        disabled_successfully = await state_change
+
+    def raise_cancellation() -> None:
+        if cancellation is not None:
+            raise cancellation
+
+    if data.unloaded:
+        if disabled_successfully and was_enabled:
+            if not await runtime_ports.async_set_automation_state(hass, entity_id, enabled=True):
+                _LOGGER.warning("Failed to restore %s after unload interrupted scheduled disable", entity_id)
+        raise_cancellation()
+        return
 
     stale_after_disable = False
     undo_stale_disable = False
@@ -120,11 +140,17 @@ async def async_execute_scheduled_disable(
         if not await runtime_ports.async_save(data):
             _raise_save_failed()
 
+    if data.unloaded:
+        raise_cancellation()
+        return
+
     if undo_stale_disable:
         if not await runtime_ports.async_set_automation_state(hass, entity_id, enabled=True):
             _LOGGER.warning("Failed to undo stale scheduled disable for %s", entity_id)
+        raise_cancellation()
         return
     if stale_after_disable:
+        raise_cancellation()
         return
     if early_notify:
         if skip_retry_log:
@@ -139,8 +165,10 @@ async def async_execute_scheduled_disable(
                 retry_log_at,
             )
         data.notify()
+        raise_cancellation()
         return
     if success_paused is None:
+        raise_cancellation()
         return
     data.notify()
     await notify_started(hass, [success_paused])
@@ -166,6 +194,7 @@ async def async_execute_scheduled_disable(
         source="timer",
     )
     _LOGGER.info("Executed scheduled snooze for %s until %s", entity_id, resume_at)
+    raise_cancellation()
 
 
 async def async_cancel_scheduled_batch(
@@ -181,6 +210,7 @@ async def async_cancel_scheduled_batch(
             return
         if not entity_ids:
             return
+        entity_ids = list(dict.fromkeys(entity_ids))
 
         async with data.lock:
             for entity_id in entity_ids:

--- a/custom_components/autosnooze/infrastructure/storage.py
+++ b/custom_components/autosnooze/infrastructure/storage.py
@@ -22,41 +22,42 @@ async def async_save(
     if data.store is None:
         return True
 
-    save_data = {
-        "paused": data.get_paused_dict(),
-        "scheduled": data.get_scheduled_dict(),
-    }
+    async with data.save_lock:
+        save_data = {
+            "paused": data.get_paused_dict(),
+            "scheduled": data.get_scheduled_dict(),
+        }
 
-    for attempt, delay in enumerate(SAVE_RETRY_DELAYS, start=1):
+        for attempt, delay in enumerate(SAVE_RETRY_DELAYS, start=1):
+            try:
+                result = data.store.async_save(save_data)
+                if isawaitable(result):
+                    await result
+                return True
+            except TRANSIENT_ERRORS as err:
+                _LOGGER.warning(
+                    "Save attempt %d failed, retrying in %.1fs: %s",
+                    attempt,
+                    delay,
+                    err,
+                )
+                await sleep(delay)
+            except Exception as err:
+                _LOGGER.error("Failed to save data: %s", err)
+                return False
+
         try:
             result = data.store.async_save(save_data)
             if isawaitable(result):
                 await result
             return True
         except TRANSIENT_ERRORS as err:
-            _LOGGER.warning(
-                "Save attempt %d failed, retrying in %.1fs: %s",
-                attempt,
-                delay,
+            _LOGGER.error(
+                "Failed to save data after %d attempts: %s",
+                MAX_SAVE_RETRIES + 1,
                 err,
             )
-            await sleep(delay)
+            return False
         except Exception as err:
             _LOGGER.error("Failed to save data: %s", err)
             return False
-
-    try:
-        result = data.store.async_save(save_data)
-        if isawaitable(result):
-            await result
-        return True
-    except TRANSIENT_ERRORS as err:
-        _LOGGER.error(
-            "Failed to save data after %d attempts: %s",
-            MAX_SAVE_RETRIES + 1,
-            err,
-        )
-        return False
-    except Exception as err:
-        _LOGGER.error("Failed to save data: %s", err)
-        return False

--- a/custom_components/autosnooze/infrastructure/telemetry.py
+++ b/custom_components/autosnooze/infrastructure/telemetry.py
@@ -455,13 +455,13 @@ class TelemetryClient:
                 },
             }
 
-            self._posthog.capture(
+            capture_id = self._posthog.capture(
                 event,
                 distinct_id=distinct_id,
                 properties=payload,
                 disable_geoip=True,
             )
-            if throttle is not None:
+            if throttle is not None and capture_id is not None:
                 self._record_emitted_once_per_utc_day(*throttle)
         except Exception:
             _LOGGER.debug("Telemetry track failed", exc_info=True)

--- a/custom_components/autosnooze/models.py
+++ b/custom_components/autosnooze/models.py
@@ -96,6 +96,7 @@ class PausedAutomation:
             "hours": self.hours,
             "minutes": self.minutes,
             "notification_trigger": self.notification_trigger,
+            "resume_retries": self.resume_retries,
         }
         if self.disable_at is not None:
             result["disable_at"] = self.disable_at.isoformat()
@@ -123,6 +124,7 @@ class PausedAutomation:
             disable_at=disable_at,
             notification_trigger=notification_trigger,
             notification_lead_minutes=notification_lead_minutes,
+            resume_retries=data.get("resume_retries", 0),
         )
 
 

--- a/custom_components/autosnooze/runtime/restore.py
+++ b/custom_components/autosnooze/runtime/restore.py
@@ -63,6 +63,14 @@ def validate_stored_entry(
             if not isinstance(value, (int, float)) or value < 0:
                 _LOGGER.warning("Invalid data for %s: %s must be non-negative, got %s", entity_id, field_name, value)
                 return False
+        resume_retries = entry_data.get("resume_retries", 0)
+        if type(resume_retries) is not int or resume_retries < 0:
+            _LOGGER.warning(
+                "Invalid data for %s: resume_retries must be a non-negative integer, got %s",
+                entity_id,
+                resume_retries,
+            )
+            return False
 
     try:
         validate_notification_config(
@@ -142,7 +150,9 @@ async def async_load_stored(
     scheduled_to_execute: list[ScheduledSnooze] = []
     scheduled_to_restore: list[ScheduledSnooze] = []
     restored_paused: list[PausedAutomation] = []
+    failed_pause_ids: set[str] = set()
     executed_scheduled: list[ScheduledSnooze] = []
+    failed_schedule_ids: set[str] = set()
     restored_started: list[PausedAutomation] = []
 
     for entity_id, info in validated.get("paused", {}).items():
@@ -184,18 +194,20 @@ async def async_load_stored(
         if await callbacks.set_automation_state(hass, paused.entity_id, enabled=False):
             restored_paused.append(paused)
         else:
-            _LOGGER.warning("Failed to restore paused state for %s, removing from storage", paused.entity_id)
-            expired.append(paused.entity_id)
+            _LOGGER.warning("Failed to restore paused state for %s; preserving entry", paused.entity_id)
+            restored_paused.append(paused)
+            failed_pause_ids.add(paused.entity_id)
 
     for scheduled in scheduled_to_execute:
         if await callbacks.set_automation_state(hass, scheduled.entity_id, enabled=False):
             executed_scheduled.append(scheduled)
         else:
             _LOGGER.warning(
-                "Failed to execute scheduled disable for %s, removing from storage",
+                "Failed to execute scheduled disable for %s; preserving entry",
                 scheduled.entity_id,
             )
-            expired_scheduled.append(scheduled.entity_id)
+            scheduled_to_restore.append(scheduled)
+            failed_schedule_ids.add(scheduled.entity_id)
 
     for entity_id in expired:
         await callbacks.set_automation_state(hass, entity_id, enabled=True)
@@ -216,7 +228,8 @@ async def async_load_stored(
 
             data.paused[paused.entity_id] = paused
             callbacks.schedule_resume(hass, data, paused.entity_id, paused.resume_at)
-            pre_resume_targets.append(paused)
+            if paused.entity_id not in failed_pause_ids:
+                pre_resume_targets.append(paused)
 
         for scheduled in executed_scheduled:
             paused = PausedAutomation(
@@ -256,7 +269,8 @@ async def async_load_stored(
                 continue
 
             data.scheduled[scheduled.entity_id] = scheduled
-            callbacks.schedule_disable(hass, data, scheduled.entity_id, scheduled)
+            if scheduled.entity_id not in failed_schedule_ids:
+                callbacks.schedule_disable(hass, data, scheduled.entity_id, scheduled)
 
         if expired or expired_scheduled or restored_started:
             should_save = True

--- a/custom_components/autosnooze/runtime/restore.py
+++ b/custom_components/autosnooze/runtime/restore.py
@@ -269,8 +269,7 @@ async def async_load_stored(
                 continue
 
             data.scheduled[scheduled.entity_id] = scheduled
-            if scheduled.entity_id not in failed_schedule_ids:
-                callbacks.schedule_disable(hass, data, scheduled.entity_id, scheduled)
+            callbacks.schedule_disable(hass, data, scheduled.entity_id, scheduled)
 
         if expired or expired_scheduled or restored_started:
             should_save = True

--- a/custom_components/autosnooze/runtime/state.py
+++ b/custom_components/autosnooze/runtime/state.py
@@ -36,6 +36,7 @@ class AutomationPauseData:
     telemetry: TelemetryClient | None = None
     hass: HomeAssistant | None = None
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    save_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     unloaded: bool = False
     startup_listener_unsub: Callable[[], None] | None = None
 

--- a/custom_components/autosnooze/runtime/timers.py
+++ b/custom_components/autosnooze/runtime/timers.py
@@ -17,7 +17,7 @@ from .state import AutomationPauseData
 ResumeReason = Literal["manual", "expired"]
 ResumeCallback = Callable[..., Coroutine[Any, Any, None]]
 ScheduledDisableCallback = Callable[[HomeAssistant, AutomationPauseData, str, datetime], Coroutine[Any, Any, None]]
-NotificationCallback = Callable[[HomeAssistant, AutomationPauseData, str], Coroutine[Any, Any, None]]
+NotificationCallback = Callable[[HomeAssistant, AutomationPauseData, str, PausedAutomation], Coroutine[Any, Any, None]]
 
 
 async_track_point_in_time = ha_async_track_point_in_time
@@ -85,7 +85,7 @@ def schedule_pre_resume_notification(
     if notify_at <= now:
         if paused.resume_at <= now:
             return False
-        hass.async_create_task(notification_callback(hass, data, paused.entity_id))
+        hass.async_create_task(notification_callback(hass, data, paused.entity_id, paused))
         return True
 
     schedule_at = track_point_in_time or async_track_point_in_time
@@ -94,7 +94,7 @@ def schedule_pre_resume_notification(
     def on_notification_timer(_now: datetime) -> None:
         if data.unloaded:
             return
-        hass.async_create_task(notification_callback(hass, data, paused.entity_id))
+        hass.async_create_task(notification_callback(hass, data, paused.entity_id, paused))
 
     data.notification_timers[paused.entity_id] = schedule_at(hass, on_notification_timer, notify_at)
     return True

--- a/tests/helpers/posthog_privacy_capture.py
+++ b/tests/helpers/posthog_privacy_capture.py
@@ -341,8 +341,11 @@ def _start_posthog_sink() -> tuple[HTTPServer, threading.Thread, list[bytes], st
 
 
 def _stop_posthog_sink(server: HTTPServer, thread: threading.Thread) -> None:
-    server.shutdown()
-    thread.join(timeout=5)
+    try:
+        server.shutdown()
+        thread.join(timeout=5)
+    finally:
+        server.server_close()
 
 
 def _posthog_events_from_body(raw: bytes) -> list[dict[str, Any]]:

--- a/tests/test_application_pause.py
+++ b/tests/test_application_pause.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+import asyncio
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -79,3 +80,153 @@ async def test_handle_pause_service_noops_when_unloaded() -> None:
 
     validate_guardrails.assert_not_called()
     pause_automations.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pause_cancellation_restores_entities_disabled_before_commit() -> None:
+    """Cancellation must not leave disabled automations outside runtime state."""
+    from custom_components.autosnooze.application.pause import async_pause_automations
+    from custom_components.autosnooze.runtime.state import AutomationPauseData
+
+    hass = MagicMock()
+    hass.states.get.return_value = MagicMock(state="on", attributes={"friendly_name": "Test"})
+    data = AutomationPauseData(store=MagicMock())
+    service_started = asyncio.Event()
+    allow_service_finish = asyncio.Event()
+    state_calls: list[tuple[str, bool]] = []
+
+    async def set_state(_hass, entity_id: str, enabled: bool) -> bool:
+        state_calls.append((entity_id, enabled))
+        if entity_id == "automation.second" and not enabled:
+            service_started.set()
+            await allow_service_finish.wait()
+        return True
+
+    save = AsyncMock(return_value=True)
+    schedule_resume = MagicMock()
+    task = asyncio.create_task(
+        async_pause_automations(
+            hass,
+            data,
+            ["automation.first", "automation.second"],
+            minutes=5,
+            set_automation_state=set_state,
+            save_data=save,
+            notify_started_automations=AsyncMock(),
+            schedule_resume_callback=schedule_resume,
+            schedule_disable_callback=MagicMock(),
+            schedule_pre_resume_notification_callback=MagicMock(),
+        )
+    )
+    await asyncio.wait_for(service_started.wait(), timeout=1)
+
+    task.cancel()
+    allow_service_finish.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert state_calls == [
+        ("automation.first", False),
+        ("automation.second", False),
+        ("automation.first", True),
+        ("automation.second", True),
+    ]
+    assert data.paused == {}
+    assert data.timers == {}
+    schedule_resume.assert_not_called()
+    save.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_scheduled_replacement_cancellation_re_disables_woken_entities() -> None:
+    """Cancellation must restore active snoozes woken for replacement."""
+    from custom_components.autosnooze.application.pause import async_pause_automations
+    from custom_components.autosnooze.models import PausedAutomation
+    from custom_components.autosnooze.runtime.state import AutomationPauseData
+
+    now = datetime.now(UTC)
+    hass = MagicMock()
+    hass.states.get.return_value = MagicMock(state="off", attributes={"friendly_name": "Test"})
+    data = AutomationPauseData(store=MagicMock())
+    for entity_id in ("automation.first", "automation.second"):
+        data.paused[entity_id] = PausedAutomation(
+            entity_id=entity_id,
+            friendly_name=entity_id,
+            resume_at=now + timedelta(minutes=30),
+            paused_at=now,
+        )
+
+    service_started = asyncio.Event()
+    allow_service_finish = asyncio.Event()
+    state_calls: list[tuple[str, bool]] = []
+
+    async def set_state(_hass, entity_id: str, enabled: bool) -> bool:
+        state_calls.append((entity_id, enabled))
+        if entity_id == "automation.second" and enabled:
+            service_started.set()
+            await allow_service_finish.wait()
+        return True
+
+    save = AsyncMock(return_value=True)
+    schedule_disable = MagicMock()
+    task = asyncio.create_task(
+        async_pause_automations(
+            hass,
+            data,
+            ["automation.first", "automation.second"],
+            disable_at=now + timedelta(hours=1),
+            resume_at_dt=now + timedelta(hours=2),
+            set_automation_state=set_state,
+            save_data=save,
+            notify_started_automations=AsyncMock(),
+            schedule_resume_callback=MagicMock(),
+            schedule_disable_callback=schedule_disable,
+            schedule_pre_resume_notification_callback=MagicMock(),
+        )
+    )
+    await asyncio.wait_for(service_started.wait(), timeout=1)
+
+    task.cancel()
+    allow_service_finish.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert state_calls == [
+        ("automation.first", True),
+        ("automation.second", True),
+        ("automation.first", False),
+        ("automation.second", False),
+    ]
+    assert set(data.paused) == {"automation.first", "automation.second"}
+    assert data.scheduled == {}
+    schedule_disable.assert_not_called()
+    save.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pause_deduplicates_backend_targets() -> None:
+    from custom_components.autosnooze.application.pause import async_pause_automations
+    from custom_components.autosnooze.runtime.state import AutomationPauseData
+
+    hass = MagicMock()
+    hass.states.get.return_value = MagicMock(state="on", attributes={"friendly_name": "Test"})
+    data = AutomationPauseData(store=MagicMock())
+    set_state = AsyncMock(return_value=True)
+    notify_started = AsyncMock()
+
+    await async_pause_automations(
+        hass,
+        data,
+        ["automation.test", "automation.test"],
+        minutes=5,
+        set_automation_state=set_state,
+        save_data=AsyncMock(return_value=True),
+        notify_started_automations=notify_started,
+        schedule_resume_callback=MagicMock(),
+        schedule_disable_callback=MagicMock(),
+        schedule_pre_resume_notification_callback=MagicMock(),
+    )
+
+    set_state.assert_awaited_once_with(hass, "automation.test", False)
+    notify_started.assert_awaited_once()
+    assert [paused.entity_id for paused in notify_started.await_args.args[1]] == ["automation.test"]

--- a/tests/test_application_resume_batch_coverage.py
+++ b/tests/test_application_resume_batch_coverage.py
@@ -105,7 +105,7 @@ async def test_batch_resume_releases_lock_before_waiting_on_async_save() -> None
 
 
 @pytest.mark.asyncio
-async def test_batch_resume_retries_failures_and_drops_exhausted_entities() -> None:
+async def test_batch_resume_retries_failures_and_retains_exhausted_entities() -> None:
     hass = MagicMock()
     data = AutomationPauseData(store=MagicMock())
     data.paused["automation.retry"] = _paused("automation.retry")
@@ -119,7 +119,7 @@ async def test_batch_resume_retries_failures_and_drops_exhausted_entities() -> N
         await async_resume_batch(hass, data, ["automation.retry", "automation.exhausted"])
 
     assert "automation.retry" in data.paused
-    assert "automation.exhausted" not in data.paused
+    assert "automation.exhausted" in data.paused
     schedule_resume.assert_called_once()
 
 
@@ -163,7 +163,44 @@ async def test_batch_resume_redisables_entity_when_a_newer_pause_wins() -> None:
 
 
 @pytest.mark.asyncio
-async def test_single_resume_retries_then_drops_an_exhausted_entity() -> None:
+async def test_batch_resume_cancellation_restores_entities_woken_before_commit() -> None:
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    data.paused["automation.one"] = _paused("automation.one")
+    data.paused["automation.two"] = _paused("automation.two")
+    second_started = asyncio.Event()
+    allow_second_finish = asyncio.Event()
+
+    async def set_state(_hass: object, entity_id: str, *, enabled: bool) -> bool:
+        if entity_id == "automation.two" and enabled:
+            second_started.set()
+            await allow_second_finish.wait()
+        return True
+
+    with (
+        patch("custom_components.autosnooze.runtime.ports.async_set_automation_state", side_effect=set_state) as state,
+        patch("custom_components.autosnooze.runtime.ports.async_save", AsyncMock(return_value=True)) as save,
+    ):
+        task = asyncio.create_task(async_resume_batch(hass, data, ["automation.one", "automation.two"]))
+        await asyncio.wait_for(second_started.wait(), timeout=1)
+        task.cancel()
+        allow_second_finish.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert list(data.paused) == ["automation.one", "automation.two"]
+    assert [(call.args[1], call.kwargs["enabled"]) for call in state.await_args_list] == [
+        ("automation.one", True),
+        ("automation.two", True),
+        ("automation.one", False),
+        ("automation.two", False),
+    ]
+    save.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_single_resume_retries_then_retains_an_exhausted_entity() -> None:
     hass = MagicMock()
     data = AutomationPauseData(store=MagicMock())
     data.paused["automation.test"] = _paused("automation.test")
@@ -185,7 +222,7 @@ async def test_single_resume_retries_then_drops_an_exhausted_entity() -> None:
     ):
         await async_resume(hass, data, "automation.test")
 
-    assert "automation.test" not in data.paused
+    assert "automation.test" in data.paused
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1003,7 +1003,7 @@ class TestAsyncResume:
 
     @pytest.mark.asyncio
     async def test_gives_up_resume_retry_after_max_attempts(self) -> None:
-        """Verify resume stops retrying and removes entity after max retries."""
+        """Verify resume stops retrying but retains entity after max retries."""
         mock_hass = MagicMock()
         mock_store = MagicMock()
         mock_store.async_save = AsyncMock()
@@ -1027,8 +1027,7 @@ class TestAsyncResume:
         ):
             await async_resume(mock_hass, data, "automation.test")
 
-        # Entity should be removed after max retries exhausted
-        assert "automation.test" not in data.paused
+        assert "automation.test" in data.paused
         mock_schedule_resume.assert_not_called()
         mock_store.async_save.assert_called_once()
 
@@ -1636,6 +1635,115 @@ class TestAsyncExecuteScheduledDisable:
 
         assert "automation.test" not in data.paused
         assert state_calls == [False, True]
+
+    @pytest.mark.asyncio
+    async def test_task_cancellation_finishes_scheduled_disable_reconciliation(self) -> None:
+        """Cancellation after turn-off must not orphan a disabled automation."""
+        mock_hass = MagicMock()
+        mock_store = MagicMock()
+        mock_store.async_save = AsyncMock()
+        data = AutomationPauseData(store=mock_store)
+
+        now = datetime.now(UTC)
+        resume_at = now + timedelta(hours=1)
+        data.scheduled["automation.test"] = ScheduledSnooze(
+            entity_id="automation.test",
+            friendly_name="Original Name",
+            disable_at=now,
+            resume_at=resume_at,
+        )
+        data.scheduled_timers["automation.test"] = MagicMock()
+
+        service_started = asyncio.Event()
+        allow_service_finish = asyncio.Event()
+        external_enabled = True
+
+        async def slow_turn_off(*_args, enabled: bool) -> bool:
+            nonlocal external_enabled
+            external_enabled = enabled
+            service_started.set()
+            await allow_service_finish.wait()
+            return True
+
+        with (
+            patch(
+                "custom_components.autosnooze.runtime.ports.async_set_automation_state",
+                side_effect=slow_turn_off,
+            ),
+            patch("custom_components.autosnooze.runtime.ports.schedule_resume") as schedule_resume,
+            patch("custom_components.autosnooze.runtime.ports.schedule_pre_resume_notification"),
+        ):
+            disable_task = asyncio.create_task(
+                async_execute_scheduled_disable(mock_hass, data, "automation.test", resume_at)
+            )
+            await asyncio.wait_for(service_started.wait(), timeout=1)
+
+            disable_task.cancel()
+            allow_service_finish.set()
+            with pytest.raises(asyncio.CancelledError):
+                await disable_task
+
+        assert external_enabled is False
+        assert "automation.test" not in data.scheduled
+        assert "automation.test" in data.paused
+        schedule_resume.assert_called_once()
+        mock_store.async_save.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unload_during_turn_off_restores_state_without_creating_runtime_work(self) -> None:
+        """An in-flight scheduled disable must stop cleanly after unload."""
+        mock_hass = MagicMock()
+        mock_hass.states.get.return_value = MagicMock(state="on")
+        mock_store = MagicMock()
+        mock_store.async_save = AsyncMock()
+        data = AutomationPauseData(store=mock_store)
+
+        now = datetime.now(UTC)
+        resume_at = now + timedelta(hours=1)
+        data.scheduled["automation.test"] = ScheduledSnooze(
+            entity_id="automation.test",
+            friendly_name="Original Name",
+            disable_at=now,
+            resume_at=resume_at,
+        )
+
+        service_started = asyncio.Event()
+        allow_service_finish = asyncio.Event()
+        state_calls: list[bool] = []
+
+        async def slow_turn_off(*_args, enabled: bool) -> bool:
+            state_calls.append(enabled)
+            if not enabled:
+                service_started.set()
+                await allow_service_finish.wait()
+            return True
+
+        with (
+            patch(
+                "custom_components.autosnooze.runtime.ports.async_set_automation_state",
+                side_effect=slow_turn_off,
+            ),
+            patch("custom_components.autosnooze.runtime.ports.schedule_resume") as schedule_resume,
+            patch("custom_components.autosnooze.runtime.ports.schedule_pre_resume_notification"),
+            patch(
+                "custom_components.autosnooze.application.scheduled.notify_started", new_callable=AsyncMock
+            ) as notify,
+        ):
+            disable_task = asyncio.create_task(
+                async_execute_scheduled_disable(mock_hass, data, "automation.test", resume_at)
+            )
+            await asyncio.wait_for(service_started.wait(), timeout=1)
+
+            data.unloaded = True
+            allow_service_finish.set()
+            await disable_task
+
+        assert state_calls == [False, True]
+        assert "automation.test" in data.scheduled
+        assert "automation.test" not in data.paused
+        schedule_resume.assert_not_called()
+        mock_store.async_save.assert_not_awaited()
+        notify.assert_not_awaited()
 
 
 # =============================================================================

--- a/tests/test_models_coverage.py
+++ b/tests/test_models_coverage.py
@@ -230,6 +230,21 @@ class TestPausedAutomationWithDisableAt:
         # Compare timestamps (allowing for microsecond precision loss in ISO format)
         assert abs((restored.disable_at - original.disable_at).total_seconds()) < 1
 
+    def test_roundtrip_preserves_resume_retries(self) -> None:
+        """A restart must not reset a failed resume's retry budget."""
+        now = datetime.now(UTC)
+        original = PausedAutomation(
+            entity_id="automation.test",
+            friendly_name="Test",
+            resume_at=now + timedelta(hours=1),
+            paused_at=now,
+            resume_retries=3,
+        )
+
+        restored = PausedAutomation.from_dict(original.entity_id, original.to_dict())
+
+        assert restored.resume_retries == 3
+
 
 class TestScheduledSnoozeEdgeCases:
     """Edge case tests for ScheduledSnooze."""

--- a/tests/test_notify_on_resume_notifications.py
+++ b/tests/test_notify_on_resume_notifications.py
@@ -557,3 +557,33 @@ async def test_async_send_pre_resume_notification_skips_non_matching_or_missing_
     await async_send_pre_resume_notification(hass, data, "automation.missing")
 
     hass.services.async_call.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_send_pre_resume_notification_skips_replaced_pause() -> None:
+    from custom_components.autosnooze.application.notifications import send_pre_resume_notification
+
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    data = AutomationPauseData(store=MagicMock())
+    now = datetime.now(UTC)
+    old_pause = PausedAutomation(
+        entity_id="automation.kitchen",
+        friendly_name="Old Kitchen Snooze",
+        paused_at=now,
+        resume_at=now + timedelta(minutes=15),
+        notification_trigger="about_to_end",
+        notification_lead_minutes=5,
+    )
+    data.paused[old_pause.entity_id] = PausedAutomation(
+        entity_id=old_pause.entity_id,
+        friendly_name="New Kitchen Snooze",
+        paused_at=now + timedelta(minutes=1),
+        resume_at=now + timedelta(hours=1),
+        notification_trigger="about_to_end",
+        notification_lead_minutes=5,
+    )
+
+    await send_pre_resume_notification(hass, data, old_pause.entity_id, old_pause)
+
+    hass.services.async_call.assert_not_awaited()

--- a/tests/test_persistence_robustness.py
+++ b/tests/test_persistence_robustness.py
@@ -8,6 +8,7 @@ These tests verify:
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -400,3 +401,55 @@ class TestSaveFailureRecovery:
         # Runtime data should be unchanged even after save failure
         assert "automation.test" in data.paused
         assert data.paused["automation.test"].friendly_name == "Test"
+
+    @pytest.mark.asyncio
+    async def test_retry_does_not_overwrite_a_newer_save(self) -> None:
+        """An older retry must not become the final persisted snapshot."""
+        from custom_components.autosnooze.infrastructure.storage import async_save
+        from custom_components.autosnooze.models import PausedAutomation
+        from custom_components.autosnooze.runtime.state import AutomationPauseData
+
+        now = datetime.now(UTC)
+        writes: list[set[str]] = []
+        save_calls = 0
+
+        async def save(payload: dict[str, dict[str, object]]) -> None:
+            nonlocal save_calls
+            save_calls += 1
+            if save_calls == 1:
+                raise OSError("transient disk failure")
+            writes.append(set(payload["paused"]))
+
+        retry_waiting = asyncio.Event()
+        release_retry = asyncio.Event()
+
+        async def wait_before_retry(_delay: float) -> None:
+            retry_waiting.set()
+            await release_retry.wait()
+
+        store = MagicMock()
+        store.async_save = save
+        data = AutomationPauseData(store=store)
+        data.paused["automation.first"] = PausedAutomation(
+            entity_id="automation.first",
+            friendly_name="First",
+            resume_at=now + timedelta(hours=1),
+            paused_at=now,
+        )
+
+        older_save = asyncio.create_task(async_save(data, sleep=wait_before_retry))
+        await asyncio.wait_for(retry_waiting.wait(), timeout=1)
+
+        data.paused["automation.second"] = PausedAutomation(
+            entity_id="automation.second",
+            friendly_name="Second",
+            resume_at=now + timedelta(hours=1),
+            paused_at=now,
+        )
+        newer_save = asyncio.create_task(async_save(data))
+        await asyncio.sleep(0)
+        release_retry.set()
+
+        assert await older_save is True
+        assert await newer_save is True
+        assert writes[-1] == {"automation.first", "automation.second"}

--- a/tests/test_posthog_privacy.py
+++ b/tests/test_posthog_privacy.py
@@ -9,11 +9,23 @@ from pathlib import Path
 import pytest
 
 from custom_components.autosnooze.infrastructure.telemetry import EVENT_SCHEMAS
-from tests.helpers.posthog_privacy_capture import capture
+from tests.helpers.posthog_privacy_capture import (
+    _start_posthog_sink,
+    _stop_posthog_sink,
+    capture,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 GOLDEN_PATH = REPO_ROOT / "docs" / "posthog-payloads.json"
 EXPECTED = len(EVENT_SCHEMAS)
+
+
+def test_posthog_privacy_sink_closes_listening_socket(socket_enabled: None) -> None:
+    server, thread, _bodies, _host = _start_posthog_sink()
+
+    _stop_posthog_sink(server, thread)
+
+    assert server.socket.fileno() == -1
 
 
 def _publish_summary(meta: dict[str, object]) -> None:

--- a/tests/test_resume_strategies.py
+++ b/tests/test_resume_strategies.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from datetime import datetime, time, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
+from zoneinfo import ZoneInfo
 
 import pytest
 import voluptuous as vol
@@ -281,6 +282,14 @@ class TestResumeStrategyResolution:
         resolved = next_local_time_occurrence(time(6, 25))
 
         assert resolved == datetime(2026, 7, 8, 10, 25, tzinfo=timezone.utc)
+
+    def test_next_local_time_occurrence_skips_spring_forward_gap(self) -> None:
+        new_york = ZoneInfo("America/New_York")
+        now = datetime(2026, 3, 8, 1, 30, tzinfo=new_york)
+
+        resolved = next_local_time_occurrence(time(2, 30), now)
+
+        assert resolved == datetime(2026, 3, 9, 6, 30, tzinfo=timezone.utc)
 
 
 # =============================================================================

--- a/tests/test_runtime_modules.py
+++ b/tests/test_runtime_modules.py
@@ -314,6 +314,50 @@ def test_runtime_pre_resume_timer_uses_injected_callback() -> None:
     hass.async_create_task.assert_called_once()
 
 
+def test_runtime_pre_resume_timer_carries_expected_pause_identity() -> None:
+    from custom_components.autosnooze.models import PausedAutomation
+    from custom_components.autosnooze.runtime.state import AutomationPauseData
+    from custom_components.autosnooze.runtime.timers import schedule_pre_resume_notification
+
+    hass = MagicMock()
+    data = AutomationPauseData()
+    now = datetime.now(UTC)
+    paused = PausedAutomation(
+        entity_id="automation.test",
+        friendly_name="Test",
+        resume_at=now + timedelta(hours=1),
+        paused_at=now,
+        notification_trigger="about_to_end",
+        notification_lead_minutes=30,
+    )
+    scheduled_callbacks: list[object] = []
+    callback_args: list[tuple[object, ...]] = []
+
+    def track_time(_hass: object, callback: object, _when: datetime) -> MagicMock:
+        scheduled_callbacks.append(callback)
+        return MagicMock()
+
+    async def noop() -> None:
+        return None
+
+    def notification_callback(*args: object):
+        callback_args.append(args)
+        return noop()
+
+    hass.async_create_task.side_effect = lambda coro: coro.close()
+    schedule_pre_resume_notification(
+        hass,
+        data,
+        paused,
+        notification_callback=notification_callback,
+        track_point_in_time=track_time,
+    )
+
+    scheduled_callbacks[0](now)
+
+    assert callback_args == [(hass, data, "automation.test", paused)]
+
+
 def test_schedule_pre_resume_notification_requires_explicit_callback() -> None:
     """Pre-resume timers reject missing callbacks at the scheduling boundary."""
     from custom_components.autosnooze.models import PausedAutomation

--- a/tests/test_startup_recovery.py
+++ b/tests/test_startup_recovery.py
@@ -118,3 +118,44 @@ async def test_startup_recovery_replay_reregistration_is_idempotent() -> None:
     # First generation timers should have been cancelled on re-register.
     created_unsubs[0].assert_called_once()
     created_unsubs[1].assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_startup_recovery_retains_entries_when_backend_state_changes_fail() -> None:
+    now = datetime.now(UTC)
+    data = AutomationPauseData(store=MagicMock())
+    data.store.async_load = AsyncMock(
+        return_value={
+            "paused": {
+                "automation.failed_pause": {
+                    "resume_at": (now + timedelta(hours=1)).isoformat(),
+                    "paused_at": now.isoformat(),
+                },
+                "automation.restored_pause": {
+                    "resume_at": (now + timedelta(hours=2)).isoformat(),
+                    "paused_at": now.isoformat(),
+                },
+            },
+            "scheduled": {
+                "automation.failed_schedule": {
+                    "disable_at": (now - timedelta(minutes=5)).isoformat(),
+                    "resume_at": (now + timedelta(hours=3)).isoformat(),
+                }
+            },
+        }
+    )
+    data.store.async_save = AsyncMock()
+    hass = _build_hass()
+
+    async def set_state(_hass: object, entity_id: str, *, enabled: bool) -> bool:
+        assert enabled is False
+        return entity_id == "automation.restored_pause"
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("custom_components.autosnooze.runtime.ports.async_set_automation_state", set_state)
+        mp.setattr("custom_components.autosnooze.runtime.ports.schedule_resume", MagicMock())
+        await async_load_stored(hass, data)
+
+    assert set(data.paused) == {"automation.failed_pause", "automation.restored_pause"}
+    assert set(data.scheduled) == {"automation.failed_schedule"}
+    data.store.async_save.assert_not_awaited()

--- a/tests/test_telemetry_client.py
+++ b/tests/test_telemetry_client.py
@@ -122,7 +122,7 @@ def captured_captures():
         properties: dict[str, Any] | None = None,
         disable_geoip: bool | None = None,
         **_kwargs: Any,
-    ) -> None:
+    ) -> str:
         captures.append(
             {
                 "event": event,
@@ -131,6 +131,7 @@ def captured_captures():
                 "disable_geoip": disable_geoip,
             }
         )
+        return "capture-id"
 
     mock_posthog = MagicMock()
     mock_posthog.capture = MagicMock(side_effect=record_capture)
@@ -307,6 +308,19 @@ async def test_posthog_failure_does_not_consume_throttle(telemetry_client, captu
 
     assert mock_posthog.capture.call_count == 2
     assert len(captures) == 0
+
+
+@pytest.mark.asyncio
+async def test_posthog_dropped_capture_does_not_consume_throttle(telemetry_client, captured_captures) -> None:
+    _captures, mock_posthog = captured_captures
+    await telemetry_client.async_setup()
+    mock_posthog.capture.side_effect = [None, "capture-id"]
+
+    telemetry_client.track("integration_active", {}, source="startup")
+    telemetry_client.track("integration_active", {}, source="startup")
+    telemetry_client.track("integration_active", {}, source="startup")
+
+    assert mock_posthog.capture.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_validation_edge_cases.py
+++ b/tests/test_validation_edge_cases.py
@@ -85,6 +85,16 @@ class TestValidateStoredEntryEdgeCases:
         }
         assert validate_stored_entry("automation.test", data, "paused") is True
 
+    @pytest.mark.parametrize("resume_retries", [-1, 1.5, "2", True])
+    def test_rejects_invalid_resume_retry_counters(self, now: datetime, resume_retries: object) -> None:
+        data = {
+            "resume_at": (now + timedelta(hours=1)).isoformat(),
+            "paused_at": now.isoformat(),
+            "resume_retries": resume_retries,
+        }
+
+        assert validate_stored_entry("automation.test", data, "paused") is False
+
     @pytest.mark.parametrize(
         "entity_id,expected",
         [


### PR DESCRIPTION
## Summary
- serialize persistence and reconcile cancellation/unload races
- preserve failed retries and startup recovery state
- handle duplicate targets, DST gaps, and stale notifications
- harden PostHog throttling and privacy sink teardown

## Verification
- 660 backend tests passed
- 1,044 frontend tests passed
- 102 architecture contract tests passed
- Ruff, formatting, Pyright, ESLint, TypeScript, dependency, duplicate, and unused-code checks passed

## Local gate note
- Critical Playwright pre-push gate could not run because its separately provisioned Home Assistant was unavailable at localhost:8124; no frontend source files changed.