### PR TITLE
ci: strip attribution from commits and PRs

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,5 @@
+file="$1"
+root="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+tmp="$(mktemp)"
+"$root/scripts/strip-cursor-attribution" < "$file" > "$tmp"
+mv "$tmp" "$file"

--- a/scripts/gh-pr-create
+++ b/scripts/gh-pr-create
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Create a GitHub PR and strip Cursor footer lines from the body.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pr_url="$(gh pr create "$@")"
+body="$(gh pr view "$pr_url" --json body --jq '.body')"
+clean_body="$(
+  printf '%s\n' "$body" |
+    "$ROOT/scripts/strip-cursor-attribution"
+)"
+if [ "$body" != "$clean_body" ]; then
+  gh pr edit "$pr_url" --body "$clean_body"
+fi
+printf '%s\n' "$pr_url"

--- a/scripts/strip-cursor-attribution
+++ b/scripts/strip-cursor-attribution
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Filter Cursor attribution lines from commit messages and PR bodies.
+# Reads stdin, writes stdout.
+set -euo pipefail
+awk '
+  /^Made with Cursor[[:space:]]*$/ { next }
+  /^Made-with: Cursor[[:space:]]*$/ { next }
+  /^Co-authored-by: Cursor([[:space:]]|$)/ { next }
+  { print }
+'


### PR DESCRIPTION
## Summary
- Add Husky `commit-msg` to drop from commit messages.
- Add `scripts/gh-pr-create` so the same lines are stripped from PR bodies.

## Test plan
- [x] Commit in this worktree ran Husky `pre-commit` (lint-staged + JS tests) and `commit-msg`
- [ ] Confirm `scripts/gh-pr-create` leaves a PR body without attribution