### PR TITLE
fix(autosnooze): telemetry capture off the Home Assistant event loop

### DIFF
--- a/custom_components/autosnooze/infrastructure/telemetry.py
+++ b/custom_components/autosnooze/infrastructure/telemetry.py
@@ -8,6 +8,7 @@ import logging
 import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from functools import partial
 from datetime import datetime
 from queue import Empty, Queue
 from typing import Any
@@ -18,7 +19,6 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util
 from posthog import Posthog
-from posthog.utils import system_context
 
 from ..const import (
     DOMAIN,
@@ -361,6 +361,8 @@ class TelemetryClient:
     _disabled: bool = False
     _persistence_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _persistence_tasks: set[asyncio.Future[Any]] = field(default_factory=set)
+    _capture_tasks: set[asyncio.Future[Any]] = field(default_factory=set)
+    _pending_throttles: set[str] = field(default_factory=set)
 
     def is_enabled(self) -> bool:
         if self._disabled:
@@ -381,7 +383,6 @@ class TelemetryClient:
             self._install_id = install_id
             self._last_card_viewed_day = _load_stored_day(stored, "last_card_viewed_day")
             self._last_integration_active_day = _load_stored_day(stored, "last_integration_active_day")
-            await self.hass.async_add_executor_job(system_context)
             self._posthog = Posthog(
                 POSTHOG_PROJECT_API_KEY,
                 host=POSTHOG_HOST,
@@ -401,6 +402,8 @@ class TelemetryClient:
 
     async def async_unload(self) -> None:
         self._disabled = True
+        if self._capture_tasks:
+            await asyncio.gather(*self._capture_tasks, return_exceptions=True)
         if self._persistence_tasks:
             await asyncio.gather(*self._persistence_tasks, return_exceptions=True)
         client = self._posthog
@@ -431,8 +434,12 @@ class TelemetryClient:
                 throttle = ("last_card_viewed_day", "_last_card_viewed_day")
             elif event == "integration_active":
                 throttle = ("last_integration_active_day", "_last_integration_active_day")
-            if throttle is not None and not self._should_emit_once_per_utc_day(*throttle):
-                return
+            if throttle is not None:
+                storage_key, cached_attr = throttle
+                if not self._should_emit_once_per_utc_day(storage_key, cached_attr):
+                    return
+                if storage_key in self._pending_throttles:
+                    return
 
             payload = sanitize_event_properties(
                 event,
@@ -445,7 +452,8 @@ class TelemetryClient:
                 return
 
             distinct_id = self._distinct_id()
-            if distinct_id is None or self._posthog is None:
+            client = self._posthog
+            if distinct_id is None or client is None:
                 return
 
             payload = {
@@ -461,16 +469,53 @@ class TelemetryClient:
                 },
             }
 
-            capture_id = self._posthog.capture(
-                event,
-                distinct_id=distinct_id,
-                properties=payload,
-                disable_geoip=True,
+            if throttle is not None:
+                self._pending_throttles.add(throttle[0])
+
+            coroutine = self._capture_in_executor(client, event, distinct_id, payload, throttle)
+            try:
+                capture_task = self.hass.async_create_task(coroutine)
+            except Exception:
+                if throttle is not None:
+                    self._pending_throttles.discard(throttle[0])
+                coroutine.close()
+                raise
+            if isinstance(capture_task, asyncio.Future):
+                self._capture_tasks.add(capture_task)
+                capture_task.add_done_callback(self._capture_tasks.discard)
+            else:
+                if throttle is not None:
+                    self._pending_throttles.discard(throttle[0])
+                coroutine.close()
+        except Exception:
+            _LOGGER.debug("Telemetry track failed", exc_info=True)
+
+    async def _capture_in_executor(
+        self,
+        client: Posthog,
+        event: str,
+        distinct_id: str,
+        payload: dict[str, Any],
+        throttle: tuple[str, str] | None,
+    ) -> None:
+        storage_key = throttle[0] if throttle is not None else None
+        try:
+            capture_id = await self.hass.async_add_executor_job(
+                partial(
+                    client.capture,
+                    event,
+                    distinct_id=distinct_id,
+                    properties=payload,
+                    disable_geoip=True,
+                )
             )
             if throttle is not None and capture_id is not None:
                 self._record_emitted_once_per_utc_day(*throttle)
         except Exception:
-            _LOGGER.debug("Telemetry track failed", exc_info=True)
+            _LOGGER.debug("Telemetry capture failed", exc_info=True)
+        finally:
+            if storage_key is not None:
+                self._pending_throttles.discard(storage_key)
 
     def track_operation_failed(
         self,

--- a/tests/helpers/posthog_privacy_capture.py
+++ b/tests/helpers/posthog_privacy_capture.py
@@ -552,10 +552,23 @@ async def _build_client(
         capture_calls,
     )
     hass = MagicMock()
+    pending_tasks: set[asyncio.Task[Any]] = set()
+
+    def async_create_task(coro: Any) -> asyncio.Task[Any]:
+        task = asyncio.create_task(coro)
+        pending_tasks.add(task)
+        task.add_done_callback(pending_tasks.discard)
+        return task
+
+    async def async_block_till_done() -> None:
+        if pending_tasks:
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
+
     hass.async_add_executor_job = lambda callback, *args: asyncio.get_running_loop().run_in_executor(
         None, callback, *args
     )
-    hass.async_create_task = MagicMock()
+    hass.async_create_task = async_create_task
+    hass.async_block_till_done = async_block_till_done
     entry = MagicMock()
     entry.options = {"telemetry_enabled": enabled}
     store = MagicMock()
@@ -674,6 +687,7 @@ async def capture() -> dict[str, Any]:
                     card_type=spec.get("card_type"),
                 )
 
+            await hass.async_block_till_done()
             assert client._posthog is not None
             client._posthog.flush()
             golden_count = len(_wire_events(bodies))
@@ -690,6 +704,7 @@ async def capture() -> dict[str, Any]:
                     properties=_polluted_properties(spec.get("properties", {})),
                     call_data_extras=POLLUTED_CALL_DATA_EXTRAS,
                 )
+                await hass.async_block_till_done()
                 if len(enabled_capture_calls) != before:
                     extra_keys_reject_failures.append(event)
 
@@ -701,6 +716,7 @@ async def capture() -> dict[str, Any]:
                     source=spec["source"],
                     card_type=spec.get("card_type"),
                 )
+                await hass.async_block_till_done()
                 if len(enabled_capture_calls) != before:
                     extra_keys_reject_failures.append(event)
 
@@ -720,8 +736,10 @@ async def capture() -> dict[str, Any]:
                 },
                 source="card",
             )
+            await hass.async_block_till_done()
             rejected_after = len(enabled_capture_calls)
 
+            await hass.async_block_till_done()
             client._posthog.flush()
 
         for args, kwargs in enabled_constructor_calls:
@@ -772,6 +790,7 @@ async def capture() -> dict[str, Any]:
                         source=spec["source"],
                         card_type=spec.get("card_type"),
                     )
+                await disabled_hass.async_block_till_done()
                 if disabled_client._posthog is not None:
                     disabled_client._posthog.flush()
 

--- a/tests/test_report_telemetry.py
+++ b/tests/test_report_telemetry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -55,8 +56,15 @@ def telemetry_client(hass, captured_captures):
     store = MagicMock()
     store.async_load = AsyncMock(return_value={"install_id": "test-install-uuid"})
     store.async_save = AsyncMock(return_value=None)
-    hass.async_create_task = MagicMock()
+    hass.async_add_executor_job = lambda callback, *args: asyncio.get_running_loop().run_in_executor(
+        None, callback, *args
+    )
     return TelemetryClient(hass, entry, store)
+
+
+async def _drain_report_telemetry_captures(client: TelemetryClient) -> None:
+    if client._capture_tasks:
+        await asyncio.gather(*client._capture_tasks, return_exceptions=True)
 
 
 def test_report_telemetry_schema_accepts_null_optional_fields() -> None:
@@ -118,6 +126,7 @@ async def test_report_telemetry_tracks_valid_card_event(hass, telemetry_client, 
 
     await async_handle_report_telemetry(hass, data, call)
 
+    await _drain_report_telemetry_captures(telemetry_client)
     assert len(captured_captures) == 1
     assert captured_captures[0]["event"] == "wake_clicked"
     assert captured_captures[0]["properties"]["scope"] == "one"
@@ -137,6 +146,7 @@ async def test_report_telemetry_tracks_coarse_platform(hass, telemetry_client, c
 
     await async_handle_report_telemetry(hass, data, call)
 
+    await _drain_report_telemetry_captures(telemetry_client)
     assert captured_captures[0]["properties"]["platform"] == "tablet"
 
 
@@ -156,6 +166,7 @@ async def test_report_telemetry_handles_null_properties_and_card_type(
 
     await async_handle_report_telemetry(hass, data, call)
 
+    await _drain_report_telemetry_captures(telemetry_client)
     assert captured_captures == []
 
 
@@ -178,6 +189,7 @@ async def test_report_telemetry_noop_when_disabled(hass, telemetry_client, captu
 
     await async_handle_report_telemetry(hass, data, call)
 
+    await _drain_report_telemetry_captures(telemetry_client)
     assert captured_captures == []
 
 
@@ -190,6 +202,7 @@ async def test_report_telemetry_noop_when_event_not_string(hass, telemetry_clien
 
     await async_handle_report_telemetry(hass, data, call)
 
+    await _drain_report_telemetry_captures(telemetry_client)
     assert captured_captures == []
 
 
@@ -206,6 +219,7 @@ async def test_report_telemetry_ignores_non_dict_properties(hass, telemetry_clie
 
     await async_handle_report_telemetry(hass, data, call)
 
+    await _drain_report_telemetry_captures(telemetry_client)
     assert captured_captures == []
 
 
@@ -222,4 +236,5 @@ async def test_report_telemetry_coerces_bad_source_and_card_type(hass, telemetry
 
     await async_handle_report_telemetry(hass, data, call)
 
+    await _drain_report_telemetry_captures(telemetry_client)
     assert captured_captures == []

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -528,6 +528,7 @@ async def test_real_posthog_sdk_sends_privacy_filtered_integration_active(
     """Real PostHog SDK emits privacy-filtered integration_active to a local sink."""
     hass, _, _, bodies = smoke_hass_real_posthog
     entry = await setup_entry(hass)
+    await hass.async_block_till_done()
     client = entry.runtime_data.telemetry._posthog
     assert client is not None
     await hass.async_add_executor_job(client.flush)

--- a/tests/test_telemetry_client.py
+++ b/tests/test_telemetry_client.py
@@ -5,19 +5,34 @@ from __future__ import annotations
 import hashlib
 import asyncio
 import logging
+import threading
+from functools import partial
 from queue import Queue
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.exceptions import ServiceValidationError
-from posthog.utils import system_context
 
 from custom_components.autosnooze.infrastructure.telemetry import (
     TelemetryClient,
     _filter_posthog_message,
     _silence_posthog_sdk_logs,
 )
+
+
+async def _drain_capture_tasks(client: TelemetryClient) -> None:
+    if client._capture_tasks:
+        await asyncio.gather(*client._capture_tasks, return_exceptions=True)
+
+
+async def _run_executor_job(callback: Any, *args: Any) -> Any:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, callback, *args)
+
+
+def _configure_telemetry_hass(hass: Any) -> None:
+    hass.async_add_executor_job = _run_executor_job
 
 
 def test_posthog_wire_filter_removes_sdk_context() -> None:
@@ -154,7 +169,7 @@ def telemetry_client(hass, captured_captures):
     store = MagicMock()
     store.async_load = AsyncMock(return_value={"install_id": "test-install-uuid"})
     store.async_save = AsyncMock(return_value=None)
-    hass.async_create_task = MagicMock()
+    _configure_telemetry_hass(hass)
     client = TelemetryClient(hass, entry, store)
     return client
 
@@ -203,18 +218,119 @@ async def test_track_capture_failure_does_not_log_warning_or_error(telemetry_cli
         await telemetry_client.async_setup()
         mock_posthog.capture.side_effect = RuntimeError("boom")
         telemetry_client.track("integration_active", {}, source="startup")
+        await _drain_capture_tasks(telemetry_client)
         handler.emit.assert_not_called()
     finally:
         telemetry_logger.removeHandler(handler)
 
 
 @pytest.mark.asyncio
-async def test_async_setup_preloads_posthog_system_context_in_executor(telemetry_client) -> None:
-    telemetry_client.hass.async_add_executor_job = AsyncMock()
+async def test_track_capture_runs_on_executor_not_event_loop(telemetry_client, captured_captures) -> None:
+    _captures, mock_posthog = captured_captures
+    loop = asyncio.get_running_loop()
+    on_loop = False
+    executor_calls: list[Any] = []
+
+    async def recording_executor_job(callback: Any, *args: Any) -> Any:
+        executor_calls.append(callback)
+        return await loop.run_in_executor(None, callback, *args)
+
+    telemetry_client.hass.async_add_executor_job = recording_executor_job
+
+    def capture_on_loop(*_args: Any, **_kwargs: Any) -> str:
+        nonlocal on_loop
+        on_loop = asyncio.get_running_loop() is loop
+        return "capture-id"
+
+    mock_posthog.capture.side_effect = capture_on_loop
 
     await telemetry_client.async_setup()
+    telemetry_client.track("integration_active", {}, source="startup")
+    await _drain_capture_tasks(telemetry_client)
 
-    telemetry_client.hass.async_add_executor_job.assert_awaited_once_with(system_context)
+    assert on_loop is False
+    assert len(executor_calls) == 1
+    assert isinstance(executor_calls[0], partial)
+    assert executor_calls[0].func is mock_posthog.capture
+
+
+@pytest.mark.asyncio
+async def test_async_unload_waits_for_pending_capture_tasks(telemetry_client, captured_captures) -> None:
+    _captures, mock_posthog = captured_captures
+    capture_started = asyncio.Event()
+    allow_capture = threading.Event()
+
+    def slow_capture(*_args: Any, **_kwargs: Any) -> str:
+        capture_started.set()
+        allow_capture.wait(timeout=5)
+        return "capture-id"
+
+    mock_posthog.capture.side_effect = slow_capture
+
+    await telemetry_client.async_setup()
+    telemetry_client.track("wake_clicked", {"scope": "one"}, source="card")
+    await capture_started.wait()
+
+    unload_task = asyncio.create_task(telemetry_client.async_unload())
+    await asyncio.sleep(0.05)
+    assert not unload_task.done()
+
+    allow_capture.set()
+    await asyncio.wait_for(unload_task, timeout=5)
+    assert mock_posthog.disabled is True
+
+
+@pytest.mark.asyncio
+async def test_create_task_failure_discards_pending_throttle_and_allows_retry(
+    telemetry_client, captured_captures
+) -> None:
+    captures, mock_posthog = captured_captures
+    original_create_task = telemetry_client.hass.async_create_task
+
+    def failing_create_task(_coro: object) -> None:
+        raise RuntimeError("create_task failed")
+
+    await telemetry_client.async_setup()
+    telemetry_client.hass.async_create_task = failing_create_task
+
+    telemetry_client.track("integration_active", {}, source="startup")
+
+    assert "last_integration_active_day" not in telemetry_client._pending_throttles
+
+    telemetry_client.hass.async_create_task = original_create_task
+    telemetry_client.track("integration_active", {}, source="startup")
+    await _drain_capture_tasks(telemetry_client)
+
+    assert len(captures) == 1
+    assert captures[0]["event"] == "integration_active"
+    mock_posthog.capture.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_repeated_throttled_events_before_capture_complete_do_not_duplicate(
+    telemetry_client, captured_captures
+) -> None:
+    _captures, mock_posthog = captured_captures
+    capture_started = asyncio.Event()
+    allow_capture = threading.Event()
+
+    def slow_capture(*_args: Any, **_kwargs: Any) -> str:
+        capture_started.set()
+        allow_capture.wait(timeout=5)
+        return "capture-id"
+
+    mock_posthog.capture.side_effect = slow_capture
+
+    await telemetry_client.async_setup()
+    telemetry_client.track("integration_active", {}, source="startup")
+    telemetry_client.track("integration_active", {}, source="startup")
+    telemetry_client.track("integration_active", {}, source="startup")
+    await capture_started.wait()
+
+    allow_capture.set()
+    await _drain_capture_tasks(telemetry_client)
+
+    assert mock_posthog.capture.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -236,6 +352,7 @@ async def test_client_hashes_install_id_for_distinct_id(telemetry_client, captur
     captures, _mock_posthog = captured_captures
     await telemetry_client.async_setup()
     telemetry_client.track("integration_active", {}, source="startup")
+    await _drain_capture_tasks(telemetry_client)
     assert len(captures) == 1
     assert captures[0]["distinct_id"] == hashlib.sha256(b"test-install-uuid").hexdigest()
     assert "clientUser" not in captures[0]
@@ -260,6 +377,7 @@ async def test_install_id_never_in_properties(telemetry_client, captured_capture
         },
         source="card",
     )
+    await _drain_capture_tasks(telemetry_client)
     properties = captures[0]["properties"]
     assert properties is not None
     assert "test-install-uuid" not in str(properties)
@@ -271,6 +389,7 @@ async def test_capture_called_with_disable_geoip(telemetry_client, captured_capt
     captures, _mock_posthog = captured_captures
     await telemetry_client.async_setup()
     telemetry_client.track("integration_active", {}, source="startup")
+    await _drain_capture_tasks(telemetry_client)
     assert captures[0]["disable_geoip"] is True
 
 
@@ -280,6 +399,7 @@ async def test_every_event_includes_set_person_properties(telemetry_client, capt
     await telemetry_client.async_setup()
     telemetry_client.track("integration_active", {}, source="startup")
     telemetry_client.track("wake_clicked", {"scope": "one"}, source="card")
+    await _drain_capture_tasks(telemetry_client)
     for capture in captures:
         properties = capture["properties"]
         assert properties is not None
@@ -302,6 +422,7 @@ async def test_card_supplied_set_rejects_event(telemetry_client, captured_captur
         {"scope": "one", "$set": {"autosnooze_version": "evil"}, "$set_once": {"initial_autosnooze_version": "evil"}},
         source="card",
     )
+    await _drain_capture_tasks(telemetry_client)
     assert captures == []
     mock_posthog.capture.assert_not_called()
 
@@ -312,6 +433,7 @@ async def test_integration_active_throttled_once_per_day(telemetry_client, captu
     await telemetry_client.async_setup()
     telemetry_client.track("integration_active", {}, source="startup")
     telemetry_client.track("integration_active", {}, source="startup")
+    await _drain_capture_tasks(telemetry_client)
     assert len(captures) == 1
 
 
@@ -321,6 +443,7 @@ async def test_card_viewed_throttled_once_per_day(hass, telemetry_client, captur
     await telemetry_client.async_setup()
     telemetry_client.track("card_viewed", {"card_type": "full"}, source="card", card_type="full")
     telemetry_client.track("card_viewed", {"card_type": "full"}, source="card", card_type="full")
+    await _drain_capture_tasks(telemetry_client)
     assert len(captures) == 1
 
 
@@ -343,6 +466,7 @@ async def test_invalid_daily_event_does_not_consume_throttle(telemetry_client, c
 
     telemetry_client.track("card_viewed", {}, source="card", card_type="invalid")
     telemetry_client.track("card_viewed", {"card_type": "full"}, source="card", card_type="full")
+    await _drain_capture_tasks(telemetry_client)
 
     assert len(captures) == 1
     assert captures[0]["event"] == "card_viewed"
@@ -355,7 +479,9 @@ async def test_posthog_failure_does_not_consume_throttle(telemetry_client, captu
     mock_posthog.capture.side_effect = [RuntimeError("offline"), None]
 
     telemetry_client.track("integration_active", {}, source="startup")
+    await _drain_capture_tasks(telemetry_client)
     telemetry_client.track("integration_active", {}, source="startup")
+    await _drain_capture_tasks(telemetry_client)
 
     assert mock_posthog.capture.call_count == 2
     assert len(captures) == 0
@@ -368,8 +494,10 @@ async def test_posthog_dropped_capture_does_not_consume_throttle(telemetry_clien
     mock_posthog.capture.side_effect = [None, "capture-id"]
 
     telemetry_client.track("integration_active", {}, source="startup")
+    await _drain_capture_tasks(telemetry_client)
     telemetry_client.track("integration_active", {}, source="startup")
     telemetry_client.track("integration_active", {}, source="startup")
+    await _drain_capture_tasks(telemetry_client)
 
     assert mock_posthog.capture.call_count == 2
 
@@ -429,6 +557,7 @@ async def test_capture_does_not_raise_on_posthog_failure(telemetry_client, captu
     await telemetry_client.async_setup()
     mock_posthog.capture.side_effect = RuntimeError("boom")
     telemetry_client.track("integration_active", {}, source="startup")
+    await _drain_capture_tasks(telemetry_client)
 
 
 @pytest.mark.asyncio
@@ -447,6 +576,7 @@ async def test_async_unload_disables_client_and_blocks_track(telemetry_client, c
     captures, mock_posthog = captured_captures
     await telemetry_client.async_setup()
     telemetry_client.track("integration_active", {}, source="startup")
+    await _drain_capture_tasks(telemetry_client)
     assert len(captures) == 1
 
     telemetry_client.hass.async_add_executor_job = AsyncMock()
@@ -456,6 +586,7 @@ async def test_async_unload_disables_client_and_blocks_track(telemetry_client, c
     assert telemetry_client._posthog is None
 
     telemetry_client.track("integration_active", {}, source="startup")
+    await _drain_capture_tasks(telemetry_client)
     assert len(captures) == 1
 
 
@@ -467,6 +598,8 @@ async def test_track_operation_failed_omits_invalid_strategy(telemetry_client, c
     error.translation_key = "invalid_duration"
 
     telemetry_client.track_operation_failed("pause", error, strategy="", target_count=2)
+    telemetry_client.track_operation_failed("pause", error, strategy="duration", target_count=1)
+    await _drain_capture_tasks(telemetry_client)
     properties = captures[0]["properties"]
     assert properties is not None
     assert properties["operation"] == "pause"
@@ -474,5 +607,4 @@ async def test_track_operation_failed_omits_invalid_strategy(telemetry_client, c
     assert properties["target_count"] == 2
     assert "strategy" not in properties
 
-    telemetry_client.track_operation_failed("pause", error, strategy="duration", target_count=1)
     assert captures[1]["properties"]["strategy"] == "duration"


### PR DESCRIPTION
## Summary
- `#517` only preloaded `system_context()` at setup; `Posthog.capture()` still calls it on every event, which does blocking OS probes on the HA loop.
- `track()` stays fire-and-forget. The SDK `capture()` call now runs in `hass.async_add_executor_job`.
- Daily throttles are reserved while a capture is in flight, released on create-task failure so a retry can emit.
- Unload waits for in-flight captures before disabling the client and discarding queues.

## Test plan
- [x] `pytest tests/test_telemetry_client.py tests/test_report_telemetry.py tests/test_posthog_privacy.py tests/test_smoke.py::test_real_posthog_sdk_sends_privacy_filtered_integration_active`
- [ ] Confirm pause/resume still records events without awaiting `track()`
- [ ] Reload/unload the integration and confirm no HA warning for telemetry capture