### PR TITLE
ci: add opt-out overrides for local HA E2E pre-push gate

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,24 @@
 #!/usr/bin/env sh
 
+if [ "${ALLOW_SKIP_HA_E2E:-}" = "1" ]; then
+  echo "Skipping local HA E2E gate (ALLOW_SKIP_HA_E2E=1)."
+  exit 0
+fi
+
+HA_URL="${HA_URL:-http://localhost:8124}"
+ha_host="${HA_URL#*://}"
+ha_host="${ha_host%%/*}"
+ha_host="${ha_host%%:*}"
+
+case "$ha_host" in
+  localhost|127.0.0.1) ;;
+  *)
+    if [ "${ALLOW_REMOTE_HA:-}" != "1" ]; then
+      echo "pre-push: HA_URL must target localhost or 127.0.0.1 unless ALLOW_REMOTE_HA=1." >&2
+      exit 1
+    fi
+    ;;
+esac
+
 scripts/ensure-ha-e2e.sh
 npm run e2e:critical

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -37,6 +37,21 @@ npm run e2e:report
 
 `npm run e2e:critical` runs tests tagged `@critical`. `.husky/pre-push` starts a host `hass` on port 8124 when it is not already reachable (`scripts/ensure-ha-e2e.sh`; it will `docker stop` a container occupying 8124 that is not serving HA), then runs this command before PR creation/push so the standard critical path catches card registration, resource loading, console/page errors, layout integrity, and the default loaded-card visual baseline.
 
+### Pre-push gate overrides
+
+The local HA E2E gate runs by default on `git push`. Two environment variables opt out of parts of that contract:
+
+- `ALLOW_SKIP_HA_E2E=1` — skip `scripts/ensure-ha-e2e.sh` and `npm run e2e:critical` entirely. The hook prints a short skip message and exits successfully.
+- `ALLOW_REMOTE_HA=1` — allow `HA_URL` to target a host other than `localhost` or `127.0.0.1`. Without this flag, pre-push rejects non-local `HA_URL` values before starting tests.
+
+```bash
+# Skip the Playwright local HA gate for one push
+ALLOW_SKIP_HA_E2E=1 git push
+
+# Run critical E2E against a remote HA instance
+ALLOW_REMOTE_HA=1 HA_URL=http://192.168.1.50:8123 git push
+```
+
 `npm run e2e:smoke` runs the compact release-gate workflow tagged `@smoke`.
 It covers card load, snooze, persisted rendering after reload, resume,
 invalid-input rejection, and disabling telemetry via integration options.

--- a/src/tests/e2e-visual-gate-contract.spec.ts
+++ b/src/tests/e2e-visual-gate-contract.spec.ts
@@ -21,6 +21,22 @@ describe('E2E visual gate contract', () => {
     expect(prePushHook).toMatch(/scripts\/ensure-ha-e2e\.sh/);
   });
 
+  test('allows skipping the local HA gate only when ALLOW_SKIP_HA_E2E=1', () => {
+    const prePushHook = fs.readFileSync(path.join(repoRoot, '.husky', 'pre-push'), 'utf8');
+
+    expect(prePushHook).toContain('ALLOW_SKIP_HA_E2E');
+    expect(prePushHook).toMatch(/ALLOW_SKIP_HA_E2E=1/);
+    expect(prePushHook).toMatch(/Skipping.*HA E2E/i);
+  });
+
+  test('rejects non-local HA_URL unless ALLOW_REMOTE_HA=1', () => {
+    const prePushHook = fs.readFileSync(path.join(repoRoot, '.husky', 'pre-push'), 'utf8');
+
+    expect(prePushHook).toContain('ALLOW_REMOTE_HA');
+    expect(prePushHook).toMatch(/localhost|127\.0\.0\.1/);
+    expect(prePushHook).toMatch(/ALLOW_REMOTE_HA=1/);
+  });
+
   test('starts host hass instead of docker exec into a sleep-loop container', () => {
     const ensureHa = fs.readFileSync(
       path.join(repoRoot, 'scripts', 'ensure-ha-e2e.sh'),

--- a/src/tests/e2e-visual-readme-contract.spec.ts
+++ b/src/tests/e2e-visual-readme-contract.spec.ts
@@ -19,6 +19,8 @@ describe('E2E visual README contract', () => {
       'HA_COMMUNITY_THEME',
       '@critical',
       '.husky/pre-push',
+      'ALLOW_SKIP_HA_E2E',
+      'ALLOW_REMOTE_HA',
     ].forEach((requiredText) => {
       expect(source).toContain(requiredText);
     });


### PR DESCRIPTION
## Summary

- Add `ALLOW_SKIP_HA_E2E=1` to skip the local Home Assistant Playwright gate on `git push`.
- Add `ALLOW_REMOTE_HA=1` to allow non-local `HA_URL` values; pre-push rejects remote hosts by default.
- Document both overrides in `e2e/README.md` and extend gate/readme contract tests.

## Test plan

- [x] `npx vitest run src/tests/e2e-visual-gate-contract.spec.ts src/tests/e2e-visual-readme-contract.spec.ts`
- [x] `git push` (pre-push hook ran `scripts/ensure-ha-e2e.sh` and `npm run e2e:critical` successfully)
- [ ] Review `.husky/pre-push` override behavior for expected escape hatches


Made with [Cursor](https://cursor.com)