### PR TITLE
fix: move PostHog capture off Home Assistant event loop

### DIFF
--- a/custom_components/autosnooze/infrastructure/telemetry.py
+++ b/custom_components/autosnooze/infrastructure/telemetry.py
@@ -9,6 +9,7 @@ import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
+from functools import partial
 from queue import Empty, Queue
 from typing import Any
 
@@ -364,7 +365,8 @@ class TelemetryClient:
     _last_integration_active_day: str | None = None
     _disabled: bool = False
     _persistence_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-    _persistence_tasks: set[asyncio.Future[Any]] = field(default_factory=set)
+    _pending_tasks: set[asyncio.Future[Any]] = field(default_factory=set)
+    _pending_throttles: set[tuple[str, str]] = field(default_factory=set)
 
     def is_enabled(self) -> bool:
         if self._disabled:
@@ -405,8 +407,8 @@ class TelemetryClient:
 
     async def async_unload(self) -> None:
         self._disabled = True
-        if self._persistence_tasks:
-            await asyncio.gather(*self._persistence_tasks, return_exceptions=True)
+        if self._pending_tasks:
+            await asyncio.gather(*self._pending_tasks, return_exceptions=True)
         client = self._posthog
         self._posthog = None
         if client is None:
@@ -435,7 +437,9 @@ class TelemetryClient:
                 throttle = ("last_card_viewed_day", "_last_card_viewed_day")
             elif event == "integration_active":
                 throttle = ("last_integration_active_day", "_last_integration_active_day")
-            if throttle is not None and not self._should_emit_once_per_utc_day(*throttle):
+            if throttle is not None and (
+                throttle in self._pending_throttles or not self._should_emit_once_per_utc_day(*throttle)
+            ):
                 return
 
             payload = sanitize_event_properties(
@@ -465,16 +469,42 @@ class TelemetryClient:
                 },
             }
 
-            capture_id = self._posthog.capture(
+            capture = partial(
+                self._posthog.capture,
                 event,
                 distinct_id=distinct_id,
                 properties=payload,
                 disable_geoip=True,
             )
-            if throttle is not None and capture_id is not None:
-                self._record_emitted_once_per_utc_day(*throttle)
+            if throttle is not None:
+                self._pending_throttles.add(throttle)
+            try:
+                task = self.hass.async_add_executor_job(capture)
+            except Exception:
+                if throttle is not None:
+                    self._pending_throttles.discard(throttle)
+                raise
+            self._pending_tasks.add(task)
+            task.add_done_callback(partial(self._capture_done, throttle))
         except Exception:
             _LOGGER.debug("Telemetry track failed", exc_info=True)
+
+    def _capture_done(
+        self,
+        throttle: tuple[str, str] | None,
+        task: asyncio.Future[Any],
+    ) -> None:
+        self._pending_tasks.discard(task)
+        try:
+            capture_id = task.result()
+        except Exception:
+            _LOGGER.debug("Telemetry track failed", exc_info=True)
+            capture_id = None
+        if throttle is None:
+            return
+        self._pending_throttles.discard(throttle)
+        if capture_id is not None and not self._disabled:
+            self._record_emitted_once_per_utc_day(*throttle)
 
     def track_operation_failed(
         self,
@@ -518,8 +548,8 @@ class TelemetryClient:
             coroutine.close()
             return
         if isinstance(task, asyncio.Future):
-            self._persistence_tasks.add(task)
-            task.add_done_callback(self._persistence_tasks.discard)
+            self._pending_tasks.add(task)
+            task.add_done_callback(self._pending_tasks.discard)
         else:
             coroutine.close()
 

--- a/tests/test_telemetry_client.py
+++ b/tests/test_telemetry_client.py
@@ -218,6 +218,22 @@ async def test_async_setup_preloads_posthog_system_context_in_executor(telemetry
 
 
 @pytest.mark.asyncio
+async def test_track_dispatches_posthog_capture_to_executor(telemetry_client, captured_captures) -> None:
+    _captures, mock_posthog = captured_captures
+    await telemetry_client.async_setup()
+    capture_future = asyncio.get_running_loop().create_future()
+    telemetry_client.hass.async_add_executor_job = MagicMock(return_value=capture_future)
+
+    telemetry_client.track("wake_clicked", {"scope": "one"}, source="service")
+
+    mock_posthog.capture.assert_not_called()
+    capture = telemetry_client.hass.async_add_executor_job.call_args.args[0]
+    capture_future.set_result(capture())
+    await asyncio.sleep(0)
+    mock_posthog.capture.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_disabled_client_is_noop(telemetry_client, captured_captures) -> None:
     captures, mock_posthog = captured_captures
     telemetry_client.entry.options = {"telemetry_enabled": False}
@@ -355,7 +371,9 @@ async def test_posthog_failure_does_not_consume_throttle(telemetry_client, captu
     mock_posthog.capture.side_effect = [RuntimeError("offline"), None]
 
     telemetry_client.track("integration_active", {}, source="startup")
+    await telemetry_client.hass.async_block_till_done()
     telemetry_client.track("integration_active", {}, source="startup")
+    await telemetry_client.hass.async_block_till_done()
 
     assert mock_posthog.capture.call_count == 2
     assert len(captures) == 0
@@ -368,8 +386,11 @@ async def test_posthog_dropped_capture_does_not_consume_throttle(telemetry_clien
     mock_posthog.capture.side_effect = [None, "capture-id"]
 
     telemetry_client.track("integration_active", {}, source="startup")
+    await telemetry_client.hass.async_block_till_done()
     telemetry_client.track("integration_active", {}, source="startup")
+    await telemetry_client.hass.async_block_till_done()
     telemetry_client.track("integration_active", {}, source="startup")
+    await telemetry_client.hass.async_block_till_done()
 
     assert mock_posthog.capture.call_count == 2
 


### PR DESCRIPTION
## Summary
- dispatch PostHog capture through the Home Assistant executor
- preserve daily-event throttling while captures are pending
- wait for pending telemetry work during integration unload

## Verification
- 712 backend tests passed
- Ruff lint and formatting checks passed
- branch-backed Playwright input Boolean scenarios passed: previous, on, off, and scheduled previous
- Playwright critical gate and 12-test service suite passed
- no Home Assistant blocking-call warning after telemetry capture