### PR TITLE
fix: roll back snooze state when persistence fails

### DIFF
--- a/custom_components/autosnooze/application/adjust.py
+++ b/custom_components/autosnooze/application/adjust.py
@@ -43,6 +43,7 @@ async def async_adjust_snooze_batch(
         now = dt_util.utcnow()
         updates: list[tuple[str, PausedAutomation, datetime]] = []
         pre_resume_targets: list[PausedAutomation] = []
+        original_resume_values: dict[str, tuple[datetime, int, int, int]] = {}
 
         async with data.lock:
             for entity_id in entity_ids:
@@ -70,6 +71,7 @@ async def async_adjust_snooze_batch(
                         translation_key="notification_lead_too_long",
                     )
 
+                original_resume_values[entity_id] = (paused.resume_at, paused.days, paused.hours, paused.minutes)
                 updates.append((entity_id, paused, new_resume_at))
 
             for entity_id, paused, new_resume_at in updates:
@@ -89,6 +91,16 @@ async def async_adjust_snooze_batch(
 
         if updates:
             if not await async_save(data):
+                for entity_id, (resume_at, days, hours, minutes) in original_resume_values.items():
+                    paused = data.paused[entity_id]
+                    paused.resume_at = resume_at
+                    paused.days = days
+                    paused.hours = hours
+                    paused.minutes = minutes
+                    schedule_resume(hass, data, entity_id, resume_at, resume_callback=async_resume)
+                    schedule_pre_resume_notification(
+                        hass, data, paused, notification_callback=send_pre_resume_notification
+                    )
                 _raise_save_failed()
             if delta.total_seconds() != 0:
                 delta_minutes = abs(int(delta.total_seconds() // 60))

--- a/custom_components/autosnooze/application/pause.py
+++ b/custom_components/autosnooze/application/pause.py
@@ -73,6 +73,57 @@ type ScheduleDisable = Callable[[HomeAssistant, AutomationPauseData, str, Schedu
 type SchedulePreResumeNotification = Callable[[HomeAssistant, AutomationPauseData, PausedAutomation], bool]
 
 
+def _clone_paused(data: AutomationPauseData) -> dict[str, PausedAutomation]:
+    return {
+        entity_id: PausedAutomation.from_dict(entity_id, paused.to_dict()) for entity_id, paused in data.paused.items()
+    }
+
+
+def _clone_scheduled(data: AutomationPauseData) -> dict[str, ScheduledSnooze]:
+    return {
+        entity_id: ScheduledSnooze.from_dict(entity_id, scheduled.to_dict())
+        for entity_id, scheduled in data.scheduled.items()
+    }
+
+
+async def _restore_runtime_after_save_failed(
+    hass: HomeAssistant,
+    data: AutomationPauseData,
+    paused_snapshot: dict[str, PausedAutomation],
+    scheduled_snapshot: dict[str, ScheduledSnooze],
+    entity_ids: set[str],
+    *,
+    resume_scheduler: ScheduleResume,
+    disable_scheduler: ScheduleDisable,
+    pre_resume_scheduler: SchedulePreResumeNotification,
+) -> None:
+    async with data.lock:
+        for entity_id in entity_ids:
+            cancel_timer(data, entity_id)
+            cancel_scheduled_timer(data, entity_id)
+            cancel_notification_timer(data, entity_id)
+        data.paused.clear()
+        data.paused.update(
+            {
+                entity_id: PausedAutomation.from_dict(entity_id, item.to_dict())
+                for entity_id, item in paused_snapshot.items()
+            }
+        )
+        data.scheduled.clear()
+        data.scheduled.update(
+            {
+                entity_id: ScheduledSnooze.from_dict(entity_id, item.to_dict())
+                for entity_id, item in scheduled_snapshot.items()
+            }
+        )
+
+    for paused in data.paused.values():
+        resume_scheduler(hass, data, paused.entity_id, paused.resume_at)
+        pre_resume_scheduler(hass, data, paused)
+    for scheduled in data.scheduled.values():
+        disable_scheduler(hass, data, scheduled.entity_id, scheduled)
+
+
 def _get_automations_by_filter(
     hass: HomeAssistant,
     filter_fn: Callable[[Any], bool],
@@ -449,6 +500,8 @@ async def async_pause_automations(
 
         re_disable_stale_replacements: list[str] = []
         pre_resume_targets: list[PausedAutomation] = []
+        paused_snapshot = _clone_paused(data)
+        scheduled_snapshot = _clone_scheduled(data)
         async with data.lock:
             for scheduled in scheduled_entries:
                 active_replacement = active_replacements.get(scheduled.entity_id)
@@ -488,6 +541,23 @@ async def async_pause_automations(
 
         if committed_scheduled_entries or paused_entries:
             if not await save_runtime_data(data):
+                for paused in paused_entries:
+                    if initially_enabled.get(paused.entity_id) and not await set_state(hass, paused.entity_id, True):
+                        _LOGGER.warning("Failed to restore %s after save failure", paused.entity_id)
+                for entity_id, resumed in replacement_resume_results.items():
+                    if resumed and not await set_state(hass, entity_id, False):
+                        _LOGGER.warning("Failed to restore disabled state for %s after save failure", entity_id)
+                await _restore_runtime_after_save_failed(
+                    hass,
+                    data,
+                    paused_snapshot,
+                    scheduled_snapshot,
+                    set(entity_ids) | set(active_replacements),
+                    resume_scheduler=resume_scheduler,
+                    disable_scheduler=disable_scheduler,
+                    pre_resume_scheduler=pre_resume_scheduler,
+                )
+                data.notify()
                 _raise_save_failed()
 
         for entity_id in re_disable_stale_replacements:
@@ -495,10 +565,8 @@ async def async_pause_automations(
                 _LOGGER.warning("Failed to restore disabled state for stale replacement of %s", entity_id)
 
         data.notify()
-        if turn_off_failed_entity_ids:
-            _raise_pause_failed()
-
-        await notify_started_callback(hass, paused_entries)
+        if paused_entries:
+            await notify_started_callback(hass, paused_entries)
         if any(paused.notification_trigger == NOTIFICATION_TRIGGER_START for paused in paused_entries):
             track_if_enabled(
                 data,
@@ -530,6 +598,8 @@ async def async_pause_automations(
                 hours=hours,
                 minutes=minutes,
             )
+        if turn_off_failed_entity_ids:
+            _raise_pause_failed()
     except Exception:
         outcome = "error"
         raise

--- a/custom_components/autosnooze/application/resume.py
+++ b/custom_components/autosnooze/application/resume.py
@@ -25,6 +25,33 @@ ResumeReason = Literal["manual", "expired"]
 _LOGGER = logging.getLogger(__name__)
 
 
+def _clone_paused(data: AutomationPauseData) -> dict[str, PausedAutomation]:
+    return {
+        entity_id: PausedAutomation.from_dict(entity_id, paused.to_dict()) for entity_id, paused in data.paused.items()
+    }
+
+
+async def _restore_paused_after_save_failed(
+    hass: HomeAssistant,
+    data: AutomationPauseData,
+    paused_snapshot: dict[str, PausedAutomation],
+    entity_ids: set[str],
+) -> None:
+    async with data.lock:
+        for entity_id in entity_ids:
+            cancel_timer(data, entity_id)
+            cancel_notification_timer(data, entity_id)
+        data.paused.clear()
+        data.paused.update(
+            {
+                entity_id: PausedAutomation.from_dict(entity_id, paused.to_dict())
+                for entity_id, paused in paused_snapshot.items()
+            }
+        )
+    for entity_id, paused in data.paused.items():
+        runtime_ports.schedule_resume(hass, data, entity_id, paused.resume_at, resume_callback=async_resume)
+
+
 async def async_resume(
     hass: HomeAssistant,
     data: AutomationPauseData,
@@ -43,6 +70,7 @@ async def async_resume(
     re_disable_entity = False
     retry_scheduled = False
     resumed: list[PausedAutomation] = []
+    paused_snapshot = _clone_paused(data)
     async with data.lock:
         paused = data.paused.get(entity_id)
         if expected_pause is not None and paused is not expected_pause:
@@ -67,6 +95,11 @@ async def async_resume(
                 runtime_ports.schedule_resume(hass, data, entity_id, retry_at, resume_callback=async_resume)
                 retry_scheduled = True
     if not await runtime_ports.async_save(data):
+        if woke_successfully:
+            if not await runtime_ports.async_set_automation_state(hass, entity_id, enabled=False):
+                _LOGGER.warning("Failed to restore disabled state for %s after save failure", entity_id)
+        await _restore_paused_after_save_failed(hass, data, paused_snapshot, {entity_id})
+        data.notify()
         _raise_save_failed()
     if re_disable_entity:
         if not await runtime_ports.async_set_automation_state(hass, entity_id, enabled=False):
@@ -108,6 +141,7 @@ async def async_resume_batch(
             }
             candidate_ids = list(candidates)
 
+        paused_snapshot = _clone_paused(data)
         results: dict[str, bool] = {}
         cancellation: asyncio.CancelledError | None = None
         for entity_id in candidate_ids:
@@ -162,21 +196,26 @@ async def async_resume_batch(
                         paused.resume_at = retry_at
                         runtime_ports.schedule_resume(hass, data, entity_id, retry_at, resume_callback=async_resume)
         if not await runtime_ports.async_save(data):
+            for paused in resumed:
+                if not await runtime_ports.async_set_automation_state(hass, paused.entity_id, enabled=False):
+                    _LOGGER.warning("Failed to restore disabled state for %s after save failure", paused.entity_id)
+            await _restore_paused_after_save_failed(hass, data, paused_snapshot, set(candidate_ids))
+            data.notify()
             _raise_save_failed()
         for entity_id in re_disable_entities:
             if not await runtime_ports.async_set_automation_state(hass, entity_id, enabled=False):
                 _LOGGER.warning("Failed to restore disabled state for stale resume of %s", entity_id)
         data.notify()
-        if reason == "manual" and any(not results.get(entity_id) for entity_id in candidate_ids):
-            _raise_wake_failed()
-        await notify_resumed(hass, resumed, reason=reason, save_succeeded=True)
         if resumed:
+            await notify_resumed(hass, resumed, reason=reason, save_succeeded=True)
             track_if_enabled(
                 data,
                 "snooze_ended",
                 {"reason": "timer" if reason == "expired" else "manual"},
                 source="timer" if reason == "expired" else "service",
             )
+        if reason == "manual" and any(not results.get(entity_id) for entity_id in candidate_ids):
+            _raise_wake_failed()
         if failed:
             _LOGGER.warning("Woke %d automations, %d failed and were rescheduled", woke, failed)
         else:

--- a/custom_components/autosnooze/application/scheduled.py
+++ b/custom_components/autosnooze/application/scheduled.py
@@ -17,7 +17,7 @@ from ..infrastructure.telemetry import track_if_enabled
 from ..logging_utils import _log_command, _raise_save_failed
 from ..models import PausedAutomation, ScheduledSnooze, resolve_resume_state
 from ..runtime import ports as runtime_ports
-from ..runtime.timers import cancel_scheduled_timer
+from ..runtime.timers import cancel_notification_timer, cancel_scheduled_timer, cancel_timer
 from ..runtime.state import AutomationPauseData
 from .notifications import notify_started, send_pre_resume_notification
 from .resume import async_resume
@@ -39,6 +39,13 @@ async def async_execute_scheduled_disable(
         cancel_scheduled_timer(data, entity_id)
         expected_scheduled = data.scheduled.get(entity_id)
 
+    paused_snapshot = {
+        entity_id: PausedAutomation.from_dict(entity_id, paused.to_dict()) for entity_id, paused in data.paused.items()
+    }
+    scheduled_snapshot = {
+        entity_id: ScheduledSnooze.from_dict(entity_id, scheduled.to_dict())
+        for entity_id, scheduled in data.scheduled.items()
+    }
     initial_state = hass.states.get(entity_id)
     was_enabled = initial_state is not None and initial_state.state == STATE_ON
     cancellation: asyncio.CancelledError | None = None
@@ -152,6 +159,33 @@ async def async_execute_scheduled_disable(
 
     if should_save:
         if not await runtime_ports.async_save(data):
+            if disabled_successfully and was_enabled:
+                if not await runtime_ports.async_set_automation_state(hass, entity_id, enabled=True):
+                    _LOGGER.warning("Failed to restore %s after scheduled disable save failure", entity_id)
+            async with data.lock:
+                cancel_timer(data, entity_id)
+                cancel_scheduled_timer(data, entity_id)
+                cancel_notification_timer(data, entity_id)
+                data.paused.clear()
+                data.paused.update(
+                    {eid: PausedAutomation.from_dict(eid, paused.to_dict()) for eid, paused in paused_snapshot.items()}
+                )
+                data.scheduled.clear()
+                data.scheduled.update(
+                    {
+                        eid: ScheduledSnooze.from_dict(eid, scheduled.to_dict())
+                        for eid, scheduled in scheduled_snapshot.items()
+                    }
+                )
+            for paused in data.paused.values():
+                runtime_ports.schedule_resume(
+                    hass, data, paused.entity_id, paused.resume_at, resume_callback=async_resume
+                )
+            for scheduled in data.scheduled.values():
+                runtime_ports.schedule_disable(
+                    hass, data, scheduled.entity_id, scheduled, disable_callback=async_execute_scheduled_disable
+                )
+            data.notify()
             _raise_save_failed()
 
     if data.unloaded:

--- a/custom_components/autosnooze/const.py
+++ b/custom_components/autosnooze/const.py
@@ -43,6 +43,9 @@ MINUTES_PER_YEAR = 525600
 # Minimum buffer for adjust operations
 MIN_ADJUST_BUFFER = timedelta(minutes=1)
 
+# Bounded wait for in-flight PostHog captures during telemetry unload
+TELEMETRY_UNLOAD_CAPTURE_TIMEOUT = 2.0
+
 # Retry delays for failed operations
 RESUME_RETRY_DELAY = timedelta(minutes=1)
 SCHEDULED_DISABLE_RETRY_DELAY = timedelta(minutes=1)

--- a/custom_components/autosnooze/infrastructure/telemetry.py
+++ b/custom_components/autosnooze/infrastructure/telemetry.py
@@ -21,6 +21,7 @@ from homeassistant.util import dt as dt_util
 from posthog import Posthog
 from posthog.utils import system_context
 
+from .. import const
 from ..const import (
     DOMAIN,
     RESUME_STATE_VALUES,
@@ -370,6 +371,7 @@ class TelemetryClient:
     _persistence_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _pending_tasks: set[asyncio.Future[Any]] = field(default_factory=set)
     _pending_throttles: set[tuple[str, str]] = field(default_factory=set)
+    unload_capture_timeout: float | None = None
 
     def is_enabled(self) -> bool:
         if self._disabled:
@@ -411,7 +413,21 @@ class TelemetryClient:
     async def async_unload(self) -> None:
         self._disabled = True
         if self._pending_tasks:
-            await asyncio.gather(*self._pending_tasks, return_exceptions=True)
+            pending = set(self._pending_tasks)
+            capture_timeout = (
+                self.unload_capture_timeout
+                if self.unload_capture_timeout is not None
+                else const.TELEMETRY_UNLOAD_CAPTURE_TIMEOUT
+            )
+            _done, still_pending = await asyncio.wait(
+                pending,
+                timeout=capture_timeout,
+            )
+            for task in still_pending:
+                task.cancel()
+                self._pending_tasks.discard(task)
+            if still_pending:
+                await asyncio.gather(*still_pending, return_exceptions=True)
         client = self._posthog
         self._posthog = None
         if client is None:
@@ -500,6 +516,8 @@ class TelemetryClient:
         self._pending_tasks.discard(task)
         try:
             capture_id = task.result()
+        except asyncio.CancelledError:
+            capture_id = None
         except Exception:
             _LOGGER.debug("Telemetry track failed", exc_info=True)
             capture_id = None

--- a/src/tests/card-shell-controller.spec.ts
+++ b/src/tests/card-shell-controller.spec.ts
@@ -210,4 +210,96 @@ describe('CardShellController', () => {
     expect(controller.shouldUpdate(current, hass({ ...states, 'automation.kitchen': { state: 'off' } } as never))).toBe(true);
     expect(controller.shouldUpdate(current, hass({ ...states, 'automation.new': { state: 'on' } } as never))).toBe(true);
   });
+
+  test('input_boolean state changes do not force card refresh', () => {
+    const controller = new CardShellController(vi.fn());
+    const states = {
+      'automation.kitchen': { state: 'on' },
+      'input_boolean.away_mode': { state: 'on' },
+    };
+    const current = hass(states as never);
+
+    expect(controller.shouldUpdate(current, hass({ ...states, 'input_boolean.away_mode': { state: 'off' } } as never))).toBe(false);
+  });
+
+  test('disconnect prevents pending registry retry from running', async () => {
+    const retry = vi.fn((_callback: () => void, _delay: number) => 1 as unknown as ReturnType<typeof setTimeout>);
+    const clearRetry = vi.fn();
+    const loadCategories = vi.fn().mockResolvedValue(null);
+    const controller = new CardShellController(vi.fn(), {
+      loadLabels: vi.fn().mockResolvedValue({}),
+      loadCategories,
+      loadEntities: vi.fn().mockResolvedValue({}),
+      setTimeout: retry,
+      clearTimeout: clearRetry,
+    });
+
+    await controller.connect(hass());
+    expect(retry).toHaveBeenCalledTimes(1);
+
+    controller.disconnect();
+    expect(clearRetry).toHaveBeenCalled();
+    expect(loadCategories).toHaveBeenCalledTimes(1);
+  });
+
+  test('labels can succeed while categories and entities keep retrying', async () => {
+    const retry = vi.fn((_callback: () => void, _delay: number) => 1 as unknown as ReturnType<typeof setTimeout>);
+    const clearRetry = vi.fn();
+    const loadLabels = vi.fn().mockResolvedValue({ important: { label_id: 'important', name: 'Important' } });
+    const loadCategories = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ lights: { category_id: 'lights', name: 'Lights' } });
+    const loadEntities = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ 'automation.kitchen': { entity_id: 'automation.kitchen', platform: 'automation' } });
+    const controller = new CardShellController(vi.fn(), {
+      loadLabels,
+      loadCategories,
+      loadEntities,
+      setTimeout: retry,
+      clearTimeout: clearRetry,
+    });
+
+    await controller.connect(hass());
+    expect(controller.snapshot.labels).toHaveProperty('important');
+    expect(controller.snapshot.categories).toEqual({});
+    expect(controller.snapshot.entities).toEqual({});
+    expect(retry).toHaveBeenCalledTimes(1);
+
+    const retryCallback = retry.mock.calls[0][0] as () => void;
+    retryCallback();
+    await vi.waitFor(() => {
+      expect(controller.snapshot.categories).toHaveProperty('lights');
+      expect(controller.snapshot.entities).toHaveProperty('automation.kitchen');
+    });
+    expect(loadCategories).toHaveBeenCalledTimes(2);
+    expect(loadEntities).toHaveBeenCalledTimes(2);
+  });
+
+  test('registry retry backoff doubles until the max delay', async () => {
+    const delays: number[] = [];
+    const retry = vi.fn((callback: () => void, delay: number) => {
+      delays.push(delay);
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    });
+    const clearRetry = vi.fn();
+    const loadCategories = vi.fn().mockResolvedValue(null);
+    const controller = new CardShellController(vi.fn(), {
+      loadLabels: vi.fn().mockResolvedValue({}),
+      loadCategories,
+      loadEntities: vi.fn().mockResolvedValue({}),
+      setTimeout: retry,
+      clearTimeout: clearRetry,
+    });
+
+    await controller.connect(hass());
+    const firstCallback = retry.mock.calls[0][0] as () => void;
+    firstCallback();
+    await Promise.resolve();
+    const secondCallback = retry.mock.calls[1][0] as () => void;
+    secondCallback();
+    await Promise.resolve();
+
+    expect(delays).toEqual([1000, 2000]);
+  });
 });

--- a/tests/test_application_pause.py
+++ b/tests/test_application_pause.py
@@ -502,7 +502,8 @@ async def test_pause_persists_partial_success_then_raises_pause_failed() -> None
     assert exc_info.value.translation_key == "pause_failed"
     assert set(data.paused) == {"automation.a"}
     save.assert_awaited_once()
-    notify_started.assert_not_awaited()
+    notify_started.assert_awaited_once()
+    assert [paused.entity_id for paused in notify_started.await_args.args[1]] == ["automation.a"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_application_resume_batch_coverage.py
+++ b/tests/test_application_resume_batch_coverage.py
@@ -12,6 +12,7 @@ from custom_components.autosnooze.application.resume import (
     async_resume,
     async_resume_batch,
 )
+from custom_components.autosnooze.domain.notifications import NOTIFICATION_TRIGGER_NONE
 from custom_components.autosnooze.models import PausedAutomation
 from custom_components.autosnooze.runtime.state import AutomationPauseData
 
@@ -26,7 +27,7 @@ def _paused(entity_id: str, *, retries: int = 0, trigger: str | None = None) -> 
         resume_at=now + timedelta(hours=1),
         paused_at=now,
         resume_retries=retries,
-        notification_trigger=trigger,
+        notification_trigger=trigger if trigger is not None else NOTIFICATION_TRIGGER_NONE,
     )
 
 
@@ -194,8 +195,15 @@ async def test_batch_resume_raises_when_partial_turn_on_fail_for_manual_reason()
         data.paused["automation.b"].resume_at,
         resume_callback=async_resume,
     )
-    notify_resumed.assert_not_awaited()
-    track_if_enabled.assert_not_called()
+    notify_resumed.assert_awaited_once()
+    resumed_entities = [paused.entity_id for paused in notify_resumed.await_args.args[1]]
+    assert resumed_entities == ["automation.a"]
+    track_if_enabled.assert_called_once_with(
+        data,
+        "snooze_ended",
+        {"reason": "manual"},
+        source="service",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_application_resume_batch_coverage.py
+++ b/tests/test_application_resume_batch_coverage.py
@@ -212,12 +212,18 @@ async def test_batch_resume_raises_when_persistence_fails() -> None:
     data = AutomationPauseData(store=MagicMock())
     data.paused["automation.test"] = _paused("automation.test")
 
+    set_state = AsyncMock(return_value=True)
     with (
-        patch("custom_components.autosnooze.runtime.ports.async_set_automation_state", AsyncMock(return_value=True)),
+        patch("custom_components.autosnooze.runtime.ports.async_set_automation_state", set_state),
         patch("custom_components.autosnooze.runtime.ports.async_save", AsyncMock(return_value=False)),
+        patch("custom_components.autosnooze.runtime.ports.schedule_resume"),
         pytest.raises(ServiceValidationError, match="Failed to persist autosnooze state"),
     ):
         await async_resume_batch(hass, data, ["automation.test"])
+
+    assert "automation.test" in data.paused
+    assert set_state.await_args_list[0].kwargs == {"enabled": True}
+    assert set_state.await_args_list[-1].kwargs == {"enabled": False}
 
 
 @pytest.mark.asyncio

--- a/tests/test_chaos_release_040.py
+++ b/tests/test_chaos_release_040.py
@@ -1,0 +1,619 @@
+"""Chaos and fault-injection tests for AutoSnooze 0.4.0 release behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.const import STATE_ON
+from homeassistant.exceptions import ServiceValidationError
+
+from custom_components.autosnooze.application.adjust import async_adjust_snooze_batch
+from custom_components.autosnooze.application.pause import (
+    async_pause_automations,
+    get_automations_by_area,
+    get_automations_by_label,
+    validate_guardrails,
+)
+from custom_components.autosnooze.application.resume import async_resume_batch
+from custom_components.autosnooze.application.scheduled import async_execute_scheduled_disable
+from custom_components.autosnooze.models import PausedAutomation, ScheduledSnooze
+from custom_components.autosnooze.runtime.state import AutomationPauseData
+
+UTC = timezone.utc
+
+
+def _state(entity_id: str, state: str = STATE_ON, friendly_name: str | None = None) -> MagicMock:
+    attrs = {"friendly_name": friendly_name or entity_id}
+    return MagicMock(state=state, attributes=attrs)
+
+
+def _build_hass(states: dict[str, MagicMock]) -> MagicMock:
+    hass = MagicMock()
+    hass.states.get.side_effect = states.get
+    return hass
+
+
+def _paused(entity_id: str, *, resume_state: str = "on", resume_in: timedelta | None = None) -> PausedAutomation:
+    now = datetime.now(UTC)
+    return PausedAutomation(
+        entity_id=entity_id,
+        friendly_name=entity_id,
+        resume_at=now + (resume_in or timedelta(hours=1)),
+        paused_at=now,
+        resume_state=resume_state,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mixed_batch_resume_state_off_keeps_automation_on_only() -> None:
+    """Mixed batches force automations to resume on while booleans honor resume_state=off."""
+    automation_id = "automation.arrival"
+    boolean_id = "input_boolean.away_mode"
+    hass = _build_hass(
+        {
+            automation_id: _state(automation_id),
+            boolean_id: _state(boolean_id, "on"),
+        }
+    )
+    data = AutomationPauseData(store=MagicMock())
+    set_state = AsyncMock(return_value=True)
+
+    await async_pause_automations(
+        hass,
+        data,
+        [automation_id, boolean_id],
+        minutes=15,
+        resume_state="off",
+        set_automation_state=set_state,
+        save_data=AsyncMock(return_value=True),
+        notify_started_automations=AsyncMock(),
+        schedule_resume_callback=MagicMock(),
+        schedule_disable_callback=MagicMock(),
+        schedule_pre_resume_notification_callback=MagicMock(),
+    )
+
+    assert data.paused[automation_id].resume_state == "on"
+    assert data.paused[boolean_id].resume_state == "off"
+
+
+@pytest.mark.asyncio
+async def test_mixed_batch_missing_entity_turn_off_failure_and_success() -> None:
+    """Missing entities are skipped, successes persist, then pause_failed is raised."""
+    existing_ok = "automation.ok"
+    existing_fail = "automation.fail"
+    missing = "automation.missing"
+    hass = _build_hass(
+        {
+            existing_ok: _state(existing_ok),
+            existing_fail: _state(existing_fail),
+        }
+    )
+    data = AutomationPauseData(store=MagicMock())
+
+    async def set_state(_hass: object, entity_id: str, enabled: bool) -> bool:
+        return entity_id == existing_ok and not enabled
+
+    save = AsyncMock(return_value=True)
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await async_pause_automations(
+            hass,
+            data,
+            [existing_ok, existing_fail, missing],
+            minutes=10,
+            set_automation_state=set_state,
+            save_data=save,
+            notify_started_automations=AsyncMock(),
+            schedule_resume_callback=MagicMock(),
+            schedule_disable_callback=MagicMock(),
+            schedule_pre_resume_notification_callback=MagicMock(),
+        )
+
+    assert exc_info.value.translation_key == "pause_failed"
+    assert set(data.paused) == {existing_ok}
+    save.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_pause_and_wake_same_input_boolean() -> None:
+    """After pause commits, overlapping wake and re-pause must not leave a disabled orphan."""
+    entity_id = "input_boolean.mode"
+    hass = _build_hass({entity_id: _state(entity_id, "on")})
+    data = AutomationPauseData(store=MagicMock())
+
+    await async_pause_automations(
+        hass,
+        data,
+        [entity_id],
+        minutes=5,
+        set_automation_state=AsyncMock(return_value=True),
+        save_data=AsyncMock(return_value=True),
+        notify_started_automations=AsyncMock(),
+        schedule_resume_callback=MagicMock(),
+        schedule_disable_callback=MagicMock(),
+        schedule_pre_resume_notification_callback=MagicMock(),
+    )
+    assert entity_id in data.paused
+
+    resume_gate = asyncio.Event()
+    release_resume = asyncio.Event()
+    overlap_started = asyncio.Event()
+    release_overlap = asyncio.Event()
+    state_calls: list[tuple[str, bool]] = []
+
+    async def set_state(_hass: object, eid: str, enabled: bool) -> bool:
+        state_calls.append((eid, enabled))
+        if eid != entity_id:
+            return True
+        if enabled:
+            resume_gate.set()
+            await release_resume.wait()
+        else:
+            if resume_gate.is_set():
+                overlap_started.set()
+            await release_overlap.wait()
+        return True
+
+    with (
+        patch("custom_components.autosnooze.runtime.ports.async_set_automation_state", side_effect=set_state),
+        patch("custom_components.autosnooze.runtime.ports.async_save", AsyncMock(return_value=True)),
+        patch("custom_components.autosnooze.runtime.ports.schedule_resume"),
+    ):
+        wake_task = asyncio.create_task(async_resume_batch(hass, data, [entity_id], reason="manual"))
+        await asyncio.wait_for(resume_gate.wait(), timeout=1)
+
+        repause_task = asyncio.create_task(
+            async_pause_automations(
+                hass,
+                data,
+                [entity_id],
+                minutes=10,
+                set_automation_state=set_state,
+                save_data=AsyncMock(return_value=True),
+                notify_started_automations=AsyncMock(),
+                schedule_resume_callback=MagicMock(),
+                schedule_disable_callback=MagicMock(),
+                schedule_pre_resume_notification_callback=MagicMock(),
+            )
+        )
+        await asyncio.wait_for(overlap_started.wait(), timeout=1)
+        release_resume.set()
+        release_overlap.set()
+        await asyncio.gather(wake_task, repause_task)
+
+    assert (entity_id, True) in state_calls
+    assert (entity_id, False) in state_calls
+    entity_calls = [enabled for eid, enabled in state_calls if eid == entity_id]
+    if entity_id in data.paused:
+        assert entity_calls[-1] is False
+    else:
+        assert entity_calls[-1] is True
+
+
+@pytest.mark.asyncio
+async def test_manual_wake_input_boolean_resume_state_off_calls_disable_not_enable() -> None:
+    """Manual wake with resume_state=off must apply enabled=False, never turn the Boolean on."""
+    entity_id = "input_boolean.away_mode"
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    data.paused[entity_id] = _paused(entity_id, resume_state="off")
+    set_state = AsyncMock(return_value=True)
+
+    with (
+        patch("custom_components.autosnooze.runtime.ports.async_set_automation_state", set_state),
+        patch("custom_components.autosnooze.runtime.ports.async_save", AsyncMock(return_value=True)),
+        patch("custom_components.autosnooze.runtime.ports.schedule_resume"),
+        patch("custom_components.autosnooze.application.resume.notify_resumed", AsyncMock()),
+        patch("custom_components.autosnooze.application.resume.track_if_enabled"),
+    ):
+        await async_resume_batch(hass, data, [entity_id], reason="manual")
+
+    set_state.assert_awaited_once_with(hass, entity_id, enabled=False)
+    assert entity_id not in data.paused
+
+
+@pytest.mark.asyncio
+async def test_mixed_batch_resume_state_previous_splits_automation_on_and_boolean_capture() -> None:
+    """Mixed previous batches keep automations on-only while booleans capture current on/off."""
+    automation_id = "automation.morning"
+    boolean_on_id = "input_boolean.quiet_hours"
+    boolean_off_id = "input_boolean.guest_mode"
+    hass = _build_hass(
+        {
+            automation_id: _state(automation_id),
+            boolean_on_id: _state(boolean_on_id, "on"),
+            boolean_off_id: _state(boolean_off_id, "off"),
+        }
+    )
+    data = AutomationPauseData(store=MagicMock())
+
+    await async_pause_automations(
+        hass,
+        data,
+        [automation_id, boolean_on_id, boolean_off_id],
+        minutes=15,
+        resume_state="previous",
+        set_automation_state=AsyncMock(return_value=True),
+        save_data=AsyncMock(return_value=True),
+        notify_started_automations=AsyncMock(),
+        schedule_resume_callback=MagicMock(),
+        schedule_disable_callback=MagicMock(),
+        schedule_pre_resume_notification_callback=MagicMock(),
+    )
+
+    assert data.paused[automation_id].resume_state == "on"
+    assert data.paused[boolean_on_id].resume_state == "on"
+    assert data.paused[boolean_off_id].resume_state == "off"
+
+
+@pytest.mark.asyncio
+async def test_save_failure_after_boolean_pause_rolls_back_ha_and_memory() -> None:
+    """A successful turn_off with failed persistence rolls back HA and runtime state."""
+    entity_id = "input_boolean.away_mode"
+    hass = _build_hass({entity_id: _state(entity_id, "on")})
+    data = AutomationPauseData(store=MagicMock())
+    set_state = AsyncMock(return_value=True)
+    save = AsyncMock(return_value=False)
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await async_pause_automations(
+            hass,
+            data,
+            [entity_id],
+            minutes=10,
+            resume_state="off",
+            set_automation_state=set_state,
+            save_data=save,
+            notify_started_automations=AsyncMock(),
+            schedule_resume_callback=MagicMock(),
+            schedule_disable_callback=MagicMock(),
+            schedule_pre_resume_notification_callback=MagicMock(),
+        )
+
+    assert exc_info.value.translation_key == "save_failed"
+    assert entity_id not in data.paused
+    assert set_state.await_args_list[0].args == (hass, entity_id, False)
+    assert set_state.await_args_list[-1].args == (hass, entity_id, True)
+    save.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_partial_manual_wake_mixed_automation_and_boolean() -> None:
+    """Partial wake persists automation success, keeps boolean paused, and raises wake_failed."""
+    now = datetime.now(UTC)
+    automation_id = "automation.kitchen"
+    boolean_id = "input_boolean.guests"
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    data.paused[automation_id] = PausedAutomation(
+        entity_id=automation_id,
+        friendly_name=automation_id,
+        resume_at=now + timedelta(hours=1),
+        paused_at=now,
+        resume_state="on",
+    )
+    data.paused[boolean_id] = PausedAutomation(
+        entity_id=boolean_id,
+        friendly_name=boolean_id,
+        resume_at=now + timedelta(hours=1),
+        paused_at=now,
+        resume_state="off",
+    )
+
+    async def set_state(_hass: object, entity_id: str, *, enabled: bool) -> bool:
+        if entity_id == automation_id:
+            return enabled
+        return False
+
+    with (
+        patch("custom_components.autosnooze.runtime.ports.async_set_automation_state", side_effect=set_state),
+        patch("custom_components.autosnooze.runtime.ports.async_save", AsyncMock(return_value=True)) as save,
+        patch("custom_components.autosnooze.runtime.ports.schedule_resume") as schedule_resume,
+        patch("custom_components.autosnooze.application.resume.notify_resumed", AsyncMock()) as notify_resumed,
+        patch("custom_components.autosnooze.application.resume.track_if_enabled") as track_if_enabled,
+        pytest.raises(ServiceValidationError) as exc_info,
+    ):
+        await async_resume_batch(hass, data, [automation_id, boolean_id], reason="manual")
+
+    assert exc_info.value.translation_key == "wake_failed"
+    assert automation_id not in data.paused
+    assert boolean_id in data.paused
+    save.assert_awaited_once()
+    schedule_resume.assert_called_once()
+    track_if_enabled.assert_called_once()
+    assert track_if_enabled.call_args.args[1] == "snooze_ended"
+
+
+@pytest.mark.asyncio
+async def test_scheduled_previous_boolean_unavailable_then_captures_on_state() -> None:
+    """Deferred scheduled previous snoozes capture stable state once it becomes available."""
+    entity_id = "input_boolean.away_mode"
+    now = datetime.now(UTC)
+    resume_at = now + timedelta(minutes=20)
+    data = AutomationPauseData(store=MagicMock())
+    data.scheduled[entity_id] = ScheduledSnooze(
+        entity_id=entity_id,
+        friendly_name="Away",
+        disable_at=now,
+        resume_at=resume_at,
+        resume_state="previous",
+    )
+
+    unavailable = _state(entity_id, "unavailable")
+    available_on = _state(entity_id, "on")
+    hass = MagicMock()
+    hass.states.get.side_effect = [unavailable, available_on]
+    set_state = AsyncMock(return_value=True)
+
+    with (
+        patch("custom_components.autosnooze.runtime.ports.async_set_automation_state", set_state),
+        patch("custom_components.autosnooze.runtime.ports.schedule_disable") as schedule_disable,
+        patch("custom_components.autosnooze.runtime.ports.schedule_resume"),
+        patch("custom_components.autosnooze.runtime.ports.async_save", AsyncMock(return_value=True)),
+    ):
+        await async_execute_scheduled_disable(hass, data, entity_id, resume_at)
+        await async_execute_scheduled_disable(hass, data, entity_id, resume_at)
+
+    set_state.assert_awaited_once_with(hass, entity_id, enabled=False)
+    assert entity_id in data.paused
+    assert data.paused[entity_id].resume_state == "on"
+    schedule_disable.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_guardrail_confirm_term_matches_input_boolean_friendly_name() -> None:
+    """Critical keywords in a Boolean friendly name require explicit confirmation."""
+    entity_id = "input_boolean.home_alarm"
+    hass = _build_hass({entity_id: _state(entity_id, "on", friendly_name="Home Alarm Toggle")})
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        validate_guardrails(hass, [entity_id], confirm=False)
+
+    assert exc_info.value.translation_key == "confirm_required"
+
+
+@pytest.mark.asyncio
+async def test_area_and_label_discovery_stays_automation_only() -> None:
+    """Area/label discovery must never return input_boolean entities."""
+    automation = MagicMock(
+        domain="automation",
+        area_id="kitchen",
+        labels={"lights"},
+        entity_id="automation.kitchen",
+    )
+    boolean = MagicMock(
+        domain="input_boolean",
+        area_id="kitchen",
+        labels={"lights"},
+        entity_id="input_boolean.guest_mode",
+    )
+    entity_reg = MagicMock()
+    entity_reg.entities = {
+        "automation.kitchen": automation,
+        "input_boolean.guest_mode": boolean,
+    }
+
+    hass = MagicMock()
+    with patch("custom_components.autosnooze.application.pause.er.async_get", return_value=entity_reg):
+        by_area = get_automations_by_area(hass, ["kitchen"])
+        by_label = get_automations_by_label(hass, ["lights"])
+
+    assert by_area == ["automation.kitchen"]
+    assert by_label == ["automation.kitchen"]
+
+
+@pytest.mark.asyncio
+async def test_scheduled_mixed_batch_resume_state_off_splits_domains() -> None:
+    """Scheduled mixed batches keep automations on-only while booleans keep requested resume_state."""
+    automation_id = "automation.morning"
+    boolean_id = "input_boolean.quiet_hours"
+    now = datetime.now(UTC)
+    disable_at = now + timedelta(minutes=5)
+    resume_at = now + timedelta(hours=1)
+    hass = _build_hass(
+        {
+            automation_id: _state(automation_id),
+            boolean_id: _state(boolean_id, "on"),
+        }
+    )
+    data = AutomationPauseData(store=MagicMock())
+
+    await async_pause_automations(
+        hass,
+        data,
+        [automation_id, boolean_id],
+        disable_at=disable_at,
+        resume_at_dt=resume_at,
+        resume_state="off",
+        set_automation_state=AsyncMock(return_value=True),
+        save_data=AsyncMock(return_value=True),
+        notify_started_automations=AsyncMock(),
+        schedule_resume_callback=MagicMock(),
+        schedule_disable_callback=MagicMock(),
+        schedule_pre_resume_notification_callback=MagicMock(),
+    )
+
+    assert data.scheduled[automation_id].resume_state == "on"
+    assert data.scheduled[boolean_id].resume_state == "off"
+    assert automation_id not in data.paused
+    assert boolean_id not in data.paused
+
+
+@pytest.mark.asyncio
+async def test_scheduled_previous_boolean_unavailable_then_captures_off_state() -> None:
+    """Deferred scheduled previous snoozes capture off once an unavailable Boolean stabilizes."""
+    entity_id = "input_boolean.away_mode"
+    now = datetime.now(UTC)
+    resume_at = now + timedelta(minutes=20)
+    data = AutomationPauseData(store=MagicMock())
+    data.scheduled[entity_id] = ScheduledSnooze(
+        entity_id=entity_id,
+        friendly_name="Away",
+        disable_at=now,
+        resume_at=resume_at,
+        resume_state="previous",
+    )
+
+    unavailable = _state(entity_id, "unavailable")
+    available_off = _state(entity_id, "off")
+    hass = MagicMock()
+    hass.states.get.side_effect = [unavailable, available_off]
+    set_state = AsyncMock(return_value=True)
+
+    with (
+        patch("custom_components.autosnooze.runtime.ports.async_set_automation_state", set_state),
+        patch("custom_components.autosnooze.runtime.ports.schedule_disable") as schedule_disable,
+        patch("custom_components.autosnooze.runtime.ports.schedule_resume"),
+        patch("custom_components.autosnooze.runtime.ports.async_save", AsyncMock(return_value=True)),
+    ):
+        await async_execute_scheduled_disable(hass, data, entity_id, resume_at)
+        await async_execute_scheduled_disable(hass, data, entity_id, resume_at)
+
+    set_state.assert_awaited_once_with(hass, entity_id, enabled=False)
+    assert entity_id in data.paused
+    assert data.paused[entity_id].resume_state == "off"
+    schedule_disable.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_pause_cancellation_restores_input_boolean_originally_on() -> None:
+    """Cancelled pause must restore an input_boolean that was turned off mid-flight."""
+    entity_id = "input_boolean.mode"
+    hass = _build_hass({entity_id: _state(entity_id, "on")})
+    data = AutomationPauseData(store=MagicMock())
+    service_started = asyncio.Event()
+    allow_service_finish = asyncio.Event()
+    state_calls: list[tuple[str, bool]] = []
+
+    async def set_state(_hass: object, eid: str, enabled: bool) -> bool:
+        state_calls.append((eid, enabled))
+        if eid == entity_id and not enabled:
+            service_started.set()
+            await allow_service_finish.wait()
+        return True
+
+    task = asyncio.create_task(
+        async_pause_automations(
+            hass,
+            data,
+            [entity_id],
+            minutes=5,
+            set_automation_state=set_state,
+            save_data=AsyncMock(return_value=True),
+            notify_started_automations=AsyncMock(),
+            schedule_resume_callback=MagicMock(),
+            schedule_disable_callback=MagicMock(),
+            schedule_pre_resume_notification_callback=MagicMock(),
+        )
+    )
+    await asyncio.wait_for(service_started.wait(), timeout=1)
+
+    task.cancel()
+    allow_service_finish.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert state_calls == [(entity_id, False), (entity_id, True)]
+    assert data.paused == {}
+
+
+@pytest.mark.asyncio
+async def test_adjust_paused_input_boolean_extends_resume_at() -> None:
+    """Adjust must reschedule a paused input_boolean without touching backend on/off state."""
+    entity_id = "input_boolean.away_mode"
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    paused = _paused(entity_id, resume_in=timedelta(hours=2))
+    original_resume_at = paused.resume_at
+    data.paused[entity_id] = paused
+    save = AsyncMock(return_value=True)
+
+    with (
+        patch("custom_components.autosnooze.application.adjust.schedule_resume") as schedule_resume,
+        patch("custom_components.autosnooze.application.adjust.schedule_pre_resume_notification"),
+        patch("custom_components.autosnooze.application.adjust.async_save", save),
+    ):
+        await async_adjust_snooze_batch(hass, data, [entity_id], timedelta(minutes=30))
+
+    assert data.paused[entity_id].resume_at == original_resume_at + timedelta(minutes=30)
+    schedule_resume.assert_called_once()
+    save.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_adjust_mixed_automation_and_boolean_batch() -> None:
+    """Mixed adjust batches update every paused target in one save."""
+    automation_id = "automation.kitchen"
+    boolean_id = "input_boolean.guests"
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    automation_paused = _paused(automation_id, resume_in=timedelta(hours=1))
+    boolean_paused = _paused(boolean_id, resume_in=timedelta(hours=1))
+    original_automation_resume = automation_paused.resume_at
+    original_boolean_resume = boolean_paused.resume_at
+    data.paused[automation_id] = automation_paused
+    data.paused[boolean_id] = boolean_paused
+    save = AsyncMock(return_value=True)
+
+    with (
+        patch("custom_components.autosnooze.application.adjust.schedule_resume"),
+        patch("custom_components.autosnooze.application.adjust.schedule_pre_resume_notification"),
+        patch("custom_components.autosnooze.application.adjust.async_save", save),
+    ):
+        await async_adjust_snooze_batch(
+            hass,
+            data,
+            [automation_id, boolean_id],
+            timedelta(minutes=15),
+        )
+
+    assert data.paused[automation_id].resume_at == original_automation_resume + timedelta(minutes=15)
+    assert data.paused[boolean_id].resume_at == original_boolean_resume + timedelta(minutes=15)
+    save.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_adjust_save_failure_rolls_back_resume_at() -> None:
+    """Failed adjust persistence raises save_failed and restores in-memory resume_at."""
+    entity_id = "input_boolean.away_mode"
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    paused = _paused(entity_id, resume_in=timedelta(hours=2))
+    original_resume_at = paused.resume_at
+    data.paused[entity_id] = paused
+    save = AsyncMock(return_value=False)
+
+    with (
+        patch("custom_components.autosnooze.application.adjust.schedule_resume"),
+        patch("custom_components.autosnooze.application.adjust.schedule_pre_resume_notification"),
+        patch("custom_components.autosnooze.application.adjust.async_save", save),
+        pytest.raises(ServiceValidationError) as exc_info,
+    ):
+        await async_adjust_snooze_batch(hass, data, [entity_id], timedelta(minutes=30))
+
+    assert exc_info.value.translation_key == "save_failed"
+    assert data.paused[entity_id].resume_at == original_resume_at
+    save.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_adjust_time_too_short_rejects_shortening_past_buffer() -> None:
+    """Adjust must reject deltas that would end the snooze inside the minimum buffer."""
+    entity_id = "input_boolean.away_mode"
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    data.paused[entity_id] = _paused(entity_id, resume_in=timedelta(minutes=2))
+    save = AsyncMock(return_value=True)
+
+    with (
+        patch("custom_components.autosnooze.application.adjust.schedule_resume"),
+        patch("custom_components.autosnooze.application.adjust.schedule_pre_resume_notification"),
+        patch("custom_components.autosnooze.application.adjust.async_save", save),
+        pytest.raises(ServiceValidationError) as exc_info,
+    ):
+        await async_adjust_snooze_batch(hass, data, [entity_id], timedelta(minutes=-2))
+
+    assert exc_info.value.translation_key == "adjust_time_too_short"
+    save.assert_not_awaited()

--- a/tests/test_fail_closed_persistence.py
+++ b/tests/test_fail_closed_persistence.py
@@ -1,0 +1,243 @@
+"""Fail-closed persistence: save_failed rolls back HA state and runtime memory."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.const import STATE_ON
+from homeassistant.exceptions import ServiceValidationError
+
+from custom_components.autosnooze.application.adjust import async_adjust_snooze_batch
+from custom_components.autosnooze.application.pause import async_pause_automations
+from custom_components.autosnooze.application.resume import async_resume_batch
+from custom_components.autosnooze.application.scheduled import async_execute_scheduled_disable
+from custom_components.autosnooze.domain.notifications import NOTIFICATION_TRIGGER_START
+from custom_components.autosnooze.models import PausedAutomation, ScheduledSnooze
+from custom_components.autosnooze.runtime.state import AutomationPauseData
+
+UTC = timezone.utc
+
+
+def _state(entity_id: str, state: str = STATE_ON) -> MagicMock:
+    return MagicMock(state=state, attributes={"friendly_name": entity_id})
+
+
+def _paused(entity_id: str, *, resume_in: timedelta | None = None) -> PausedAutomation:
+    now = datetime.now(UTC)
+    return PausedAutomation(
+        entity_id=entity_id,
+        friendly_name=entity_id,
+        resume_at=now + (resume_in or timedelta(hours=1)),
+        paused_at=now,
+        resume_state="on",
+    )
+
+
+@pytest.mark.asyncio
+async def test_pause_save_failed_restores_ha_and_memory() -> None:
+    """save_failed after turn_off rolls back runtime state and restores HA entity."""
+    entity_id = "input_boolean.away_mode"
+    hass = MagicMock()
+    hass.states.get.return_value = _state(entity_id, "on")
+    data = AutomationPauseData(store=MagicMock())
+    set_state = AsyncMock(return_value=True)
+    save = AsyncMock(return_value=False)
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await async_pause_automations(
+            hass,
+            data,
+            [entity_id],
+            minutes=10,
+            resume_state="off",
+            set_automation_state=set_state,
+            save_data=save,
+            notify_started_automations=AsyncMock(),
+            schedule_resume_callback=MagicMock(),
+            schedule_disable_callback=MagicMock(),
+            schedule_pre_resume_notification_callback=MagicMock(),
+        )
+
+    assert exc_info.value.translation_key == "save_failed"
+    assert entity_id not in data.paused
+    assert set_state.await_args_list[0].args == (hass, entity_id, False)
+    assert set_state.await_args_list[-1].args == (hass, entity_id, True)
+    save.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_partial_pause_notifies_successes_before_pause_failed() -> None:
+    """Partial pause emits start notification for persisted successes, then raises pause_failed."""
+    existing_ok = "automation.ok"
+    existing_fail = "automation.fail"
+    hass = MagicMock()
+    hass.states.get.return_value = _state("x", "on")
+
+    def get_state(entity_id: str) -> MagicMock | None:
+        if entity_id == existing_ok:
+            return _state(existing_ok)
+        if entity_id == existing_fail:
+            return _state(existing_fail)
+        return None
+
+    hass.states.get.side_effect = get_state
+    data = AutomationPauseData(store=MagicMock())
+
+    async def set_state(_hass: object, entity_id: str, enabled: bool) -> bool:
+        return entity_id == existing_ok and not enabled
+
+    notify_started = AsyncMock()
+    save = AsyncMock(return_value=True)
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await async_pause_automations(
+            hass,
+            data,
+            [existing_ok, existing_fail],
+            minutes=10,
+            notification_trigger=NOTIFICATION_TRIGGER_START,
+            set_automation_state=set_state,
+            save_data=save,
+            notify_started_automations=notify_started,
+            schedule_resume_callback=MagicMock(),
+            schedule_disable_callback=MagicMock(),
+            schedule_pre_resume_notification_callback=MagicMock(),
+        )
+
+    assert exc_info.value.translation_key == "pause_failed"
+    assert set(data.paused) == {existing_ok}
+    notify_started.assert_awaited_once()
+    assert [p.entity_id for p in notify_started.await_args.args[1]] == [existing_ok]
+
+
+@pytest.mark.asyncio
+async def test_wake_save_failed_restores_ha_and_memory() -> None:
+    """save_failed after wake rolls back runtime state and re-disables the entity."""
+    entity_id = "input_boolean.mode"
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    data.paused[entity_id] = _paused(entity_id)
+    set_state = AsyncMock(return_value=True)
+
+    with (
+        patch("custom_components.autosnooze.runtime.ports.async_set_automation_state", set_state),
+        patch("custom_components.autosnooze.runtime.ports.async_save", AsyncMock(return_value=False)),
+        patch("custom_components.autosnooze.runtime.ports.schedule_resume"),
+        patch("custom_components.autosnooze.application.resume.notify_resumed", AsyncMock()),
+        patch("custom_components.autosnooze.application.resume.track_if_enabled"),
+        pytest.raises(ServiceValidationError) as exc_info,
+    ):
+        await async_resume_batch(hass, data, [entity_id], reason="manual")
+
+    assert exc_info.value.translation_key == "save_failed"
+    assert entity_id in data.paused
+    assert set_state.await_args_list[0].kwargs == {"enabled": True}
+    assert set_state.await_args_list[-1].kwargs == {"enabled": False}
+
+
+@pytest.mark.asyncio
+async def test_partial_wake_emits_telemetry_for_successes_before_wake_failed() -> None:
+    """Partial manual wake records snooze_ended for successes before raising wake_failed."""
+    now = datetime.now(UTC)
+    automation_id = "automation.kitchen"
+    boolean_id = "input_boolean.guests"
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    data.paused = {
+        automation_id: PausedAutomation(
+            entity_id=automation_id,
+            friendly_name=automation_id,
+            resume_at=now + timedelta(hours=1),
+            paused_at=now,
+            resume_state="on",
+        ),
+        boolean_id: PausedAutomation(
+            entity_id=boolean_id,
+            friendly_name=boolean_id,
+            resume_at=now + timedelta(hours=1),
+            paused_at=now,
+            resume_state="off",
+        ),
+    }
+
+    async def set_state(_hass: object, entity_id: str, *, enabled: bool) -> bool:
+        return entity_id == automation_id and enabled
+
+    track = MagicMock()
+    with (
+        patch("custom_components.autosnooze.runtime.ports.async_set_automation_state", side_effect=set_state),
+        patch("custom_components.autosnooze.runtime.ports.async_save", AsyncMock(return_value=True)),
+        patch("custom_components.autosnooze.runtime.ports.schedule_resume"),
+        patch("custom_components.autosnooze.application.resume.notify_resumed", AsyncMock()),
+        patch("custom_components.autosnooze.application.resume.track_if_enabled", track),
+        pytest.raises(ServiceValidationError) as exc_info,
+    ):
+        await async_resume_batch(hass, data, [automation_id, boolean_id], reason="manual")
+
+    assert exc_info.value.translation_key == "wake_failed"
+    assert automation_id not in data.paused
+    assert boolean_id in data.paused
+    track.assert_called_once()
+    assert track.call_args.args[1] == "snooze_ended"
+
+
+@pytest.mark.asyncio
+async def test_adjust_save_failed_restores_resume_at() -> None:
+    """save_failed after adjust rolls back in-memory resume_at and timer scheduling."""
+    entity_id = "input_boolean.away_mode"
+    hass = MagicMock()
+    data = AutomationPauseData(store=MagicMock())
+    paused = _paused(entity_id, resume_in=timedelta(hours=2))
+    original_resume_at = paused.resume_at
+    data.paused[entity_id] = paused
+    save = AsyncMock(return_value=False)
+    schedule_resume = MagicMock()
+
+    with (
+        patch("custom_components.autosnooze.application.adjust.schedule_resume", schedule_resume),
+        patch("custom_components.autosnooze.application.adjust.schedule_pre_resume_notification"),
+        patch("custom_components.autosnooze.application.adjust.async_save", save),
+        pytest.raises(ServiceValidationError) as exc_info,
+    ):
+        await async_adjust_snooze_batch(hass, data, [entity_id], timedelta(minutes=30))
+
+    assert exc_info.value.translation_key == "save_failed"
+    assert data.paused[entity_id].resume_at == original_resume_at
+    assert schedule_resume.call_count == 2
+    save.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_scheduled_disable_save_failed_restores_ha_and_memory() -> None:
+    """save_failed after scheduled disable rolls back HA and scheduled/paused state."""
+    entity_id = "input_boolean.away_mode"
+    now = datetime.now(UTC)
+    resume_at = now + timedelta(minutes=20)
+    data = AutomationPauseData(store=MagicMock())
+    data.scheduled[entity_id] = ScheduledSnooze(
+        entity_id=entity_id,
+        friendly_name="Away",
+        disable_at=now,
+        resume_at=resume_at,
+        resume_state="on",
+    )
+    hass = MagicMock()
+    hass.states.get.return_value = _state(entity_id, "on")
+    set_state = AsyncMock(return_value=True)
+
+    with (
+        patch("custom_components.autosnooze.runtime.ports.async_set_automation_state", set_state),
+        patch("custom_components.autosnooze.runtime.ports.schedule_disable"),
+        patch("custom_components.autosnooze.runtime.ports.schedule_resume"),
+        patch("custom_components.autosnooze.runtime.ports.async_save", AsyncMock(return_value=False)),
+        pytest.raises(ServiceValidationError) as exc_info,
+    ):
+        await async_execute_scheduled_disable(hass, data, entity_id, resume_at)
+
+    assert exc_info.value.translation_key == "save_failed"
+    assert entity_id in data.scheduled
+    assert entity_id not in data.paused
+    assert set_state.await_args_list[0].kwargs == {"enabled": False}
+    assert set_state.await_args_list[-1].kwargs == {"enabled": True}

--- a/tests/test_notify_on_resume_notifications.py
+++ b/tests/test_notify_on_resume_notifications.py
@@ -425,15 +425,19 @@ async def test_async_resume_raises_and_skips_notification_when_save_fails_after_
         notification_trigger="end",
     )
 
+    set_state = AsyncMock(return_value=True)
     with (
-        patch("custom_components.autosnooze.runtime.ports.async_set_automation_state", AsyncMock(return_value=True)),
+        patch("custom_components.autosnooze.runtime.ports.async_set_automation_state", set_state),
         patch("custom_components.autosnooze.runtime.ports.async_save", AsyncMock(return_value=False)),
+        patch("custom_components.autosnooze.runtime.ports.schedule_resume"),
         pytest.raises(ServiceValidationError, match="Failed to persist autosnooze state"),
     ):
         await async_resume(hass, data, "automation.kitchen", reason="expired")
 
     hass.services.async_call.assert_not_awaited()
-    assert "automation.kitchen" not in data.paused
+    assert "automation.kitchen" in data.paused
+    assert set_state.await_args_list[0].kwargs == {"enabled": True}
+    assert set_state.await_args_list[-1].kwargs == {"enabled": False}
 
 
 @pytest.mark.asyncio

--- a/tests/test_telemetry_client.py
+++ b/tests/test_telemetry_client.py
@@ -114,6 +114,28 @@ async def test_async_unload_discards_queued_posthog_events_after_opt_out() -> No
 
 
 @pytest.fixture
+def hass() -> MagicMock:
+    mock = MagicMock()
+
+    def run_executor_job(callback: Any) -> asyncio.Future[Any]:
+        future: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
+        try:
+            future.set_result(callback())
+        except Exception as exc:
+            future.set_exception(exc)
+        return future
+
+    mock.async_add_executor_job = run_executor_job
+    mock.async_create_task = MagicMock(side_effect=lambda coro: asyncio.create_task(coro))
+
+    async def block_till_done() -> None:
+        await asyncio.sleep(0)
+
+    mock.async_block_till_done = block_till_done
+    return mock
+
+
+@pytest.fixture
 def captured_captures():
     captures: list[dict[str, Any]] = []
 
@@ -478,6 +500,250 @@ async def test_async_unload_disables_client_and_blocks_track(telemetry_client, c
 
     telemetry_client.track("integration_active", {}, source="startup")
     assert len(captures) == 1
+
+
+def _build_captured_posthog() -> tuple[list[dict[str, Any]], MagicMock]:
+    captures: list[dict[str, Any]] = []
+
+    def record_capture(
+        event: str,
+        *,
+        distinct_id: str | None = None,
+        properties: dict[str, Any] | None = None,
+        disable_geoip: bool | None = None,
+        **_kwargs: Any,
+    ) -> str:
+        captures.append(
+            {
+                "event": event,
+                "distinct_id": distinct_id,
+                "properties": properties,
+                "disable_geoip": disable_geoip,
+            }
+        )
+        return "capture-id"
+
+    mock_posthog = MagicMock()
+    mock_posthog.capture = MagicMock(side_effect=record_capture)
+    mock_posthog.disabled = False
+    return captures, mock_posthog
+
+
+def _build_telemetry_hass() -> MagicMock:
+    hass = MagicMock()
+    hass.async_create_task = MagicMock()
+    hass.async_add_executor_job = AsyncMock(return_value=None)
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_daily_throttle_held_while_capture_is_pending() -> None:
+    """Second daily event must be dropped while the first capture is still in-flight."""
+    captures, mock_posthog = _build_captured_posthog()
+    hass = _build_telemetry_hass()
+    entry = MagicMock()
+    entry.options = {"telemetry_enabled": True}
+    store = MagicMock()
+    store.async_load = AsyncMock(return_value={"install_id": "test-install-uuid"})
+    store.async_save = AsyncMock(return_value=None)
+    capture_started = asyncio.Event()
+    release_capture = asyncio.Event()
+
+    def schedule_capture(callback: Any) -> asyncio.Task[Any]:
+        async def run() -> Any:
+            capture_started.set()
+            await release_capture.wait()
+            return callback()
+
+        return asyncio.create_task(run())
+
+    with patch(
+        "custom_components.autosnooze.infrastructure.telemetry.Posthog",
+        return_value=mock_posthog,
+    ):
+        telemetry_client = TelemetryClient(hass, entry, store)
+        await telemetry_client.async_setup()
+        telemetry_client.hass.async_add_executor_job = schedule_capture
+
+        telemetry_client.track("integration_active", {}, source="startup")
+        await asyncio.wait_for(capture_started.wait(), timeout=1)
+        telemetry_client.track("integration_active", {}, source="startup")
+        telemetry_client.track("card_viewed", {"card_type": "full"}, source="card", card_type="full")
+
+        assert mock_posthog.capture.call_count == 0
+        assert ("last_integration_active_day", "_last_integration_active_day") in telemetry_client._pending_throttles
+        assert ("last_card_viewed_day", "_last_card_viewed_day") in telemetry_client._pending_throttles
+
+        release_capture.set()
+        pending = list(telemetry_client._pending_tasks)
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        await asyncio.sleep(0)
+
+    assert mock_posthog.capture.call_count == 2
+    assert {capture["event"] for capture in captures} == {"integration_active", "card_viewed"}
+
+
+@pytest.mark.asyncio
+async def test_async_unload_waits_for_pending_executor_capture() -> None:
+    """Unload must await in-flight executor captures before shutdown."""
+    _captures, mock_posthog = _build_captured_posthog()
+    hass = _build_telemetry_hass()
+    entry = MagicMock()
+    entry.options = {"telemetry_enabled": True}
+    store = MagicMock()
+    store.async_load = AsyncMock(return_value={"install_id": "test-install-uuid"})
+    store.async_save = AsyncMock(return_value=None)
+    capture_started = asyncio.Event()
+    unload_finished = asyncio.Event()
+
+    def schedule_capture(callback: Any) -> asyncio.Task[Any]:
+        async def run() -> Any:
+            capture_started.set()
+            await asyncio.sleep(0.05)
+            return callback()
+
+        return asyncio.create_task(run())
+
+    with patch(
+        "custom_components.autosnooze.infrastructure.telemetry.Posthog",
+        return_value=mock_posthog,
+    ):
+        telemetry_client = TelemetryClient(hass, entry, store)
+        await telemetry_client.async_setup()
+        telemetry_client.hass.async_add_executor_job = schedule_capture
+        telemetry_client.track("wake_clicked", {"scope": "one"}, source="service")
+        await asyncio.wait_for(capture_started.wait(), timeout=1)
+
+        unload_task = asyncio.create_task(telemetry_client.async_unload())
+
+        async def mark_unload_done() -> None:
+            await unload_task
+            unload_finished.set()
+
+        waiter = asyncio.create_task(mark_unload_done())
+        await asyncio.sleep(0.01)
+        assert unload_finished.is_set() is False
+
+        await asyncio.wait_for(unload_finished.wait(), timeout=1)
+        await waiter
+
+    mock_posthog.capture.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_unload_returns_on_hung_executor_capture_after_timeout() -> None:
+    """Unload abandons a stuck in-flight capture after a bounded timeout."""
+    _captures, mock_posthog = _build_captured_posthog()
+    hass = _build_telemetry_hass()
+    entry = MagicMock()
+    entry.options = {"telemetry_enabled": True}
+    store = MagicMock()
+    store.async_load = AsyncMock(return_value={"install_id": "test-install-uuid"})
+    store.async_save = AsyncMock(return_value=None)
+    capture_started = asyncio.Event()
+    release_capture = asyncio.Event()
+
+    def schedule_capture(callback: Any) -> asyncio.Task[Any]:
+        async def run() -> Any:
+            capture_started.set()
+            await release_capture.wait()
+            return callback()
+
+        return asyncio.create_task(run())
+
+    with patch(
+        "custom_components.autosnooze.infrastructure.telemetry.Posthog",
+        return_value=mock_posthog,
+    ):
+        telemetry_client = TelemetryClient(hass, entry, store, unload_capture_timeout=0.05)
+        await telemetry_client.async_setup()
+        telemetry_client.hass.async_add_executor_job = schedule_capture
+        telemetry_client.track("wake_clicked", {"scope": "one"}, source="service")
+        await asyncio.wait_for(capture_started.wait(), timeout=1)
+
+        telemetry_client.hass.async_add_executor_job = AsyncMock(return_value=None)
+        await telemetry_client.async_unload()
+
+    assert mock_posthog.disabled is True
+    assert telemetry_client._posthog is None
+    mock_posthog.capture.assert_not_called()
+    release_capture.set()
+
+
+@pytest.mark.asyncio
+async def test_track_after_unload_does_not_dispatch_executor_job() -> None:
+    """Post-unload track calls must not enqueue new executor work."""
+    captures, mock_posthog = _build_captured_posthog()
+    hass = _build_telemetry_hass()
+    entry = MagicMock()
+    entry.options = {"telemetry_enabled": True}
+    store = MagicMock()
+    store.async_load = AsyncMock(return_value={"install_id": "test-install-uuid"})
+    store.async_save = AsyncMock(return_value=None)
+
+    def schedule_capture(callback: Any) -> asyncio.Task[Any]:
+        async def run() -> Any:
+            return callback()
+
+        return asyncio.create_task(run())
+
+    with patch(
+        "custom_components.autosnooze.infrastructure.telemetry.Posthog",
+        return_value=mock_posthog,
+    ):
+        telemetry_client = TelemetryClient(hass, entry, store)
+        await telemetry_client.async_setup()
+        telemetry_client.hass.async_add_executor_job = schedule_capture
+        telemetry_client.track("integration_active", {}, source="startup")
+        await asyncio.gather(*telemetry_client._pending_tasks, return_exceptions=True)
+
+        executor = AsyncMock()
+        telemetry_client.hass.async_add_executor_job = executor
+        await telemetry_client.async_unload()
+        executor.reset_mock()
+
+        telemetry_client.track("integration_active", {}, source="startup")
+        telemetry_client.track("card_viewed", {"card_type": "full"}, source="card", card_type="full")
+
+    executor.assert_not_awaited()
+    assert len(captures) == 1
+    mock_posthog.capture.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_capture_exception_does_not_break_track_caller() -> None:
+    """Executor capture failures must stay contained inside telemetry."""
+    _captures, mock_posthog = _build_captured_posthog()
+    hass = _build_telemetry_hass()
+    entry = MagicMock()
+    entry.options = {"telemetry_enabled": True}
+    store = MagicMock()
+    store.async_load = AsyncMock(return_value={"install_id": "test-install-uuid"})
+    store.async_save = AsyncMock(return_value=None)
+    mock_posthog.capture.side_effect = RuntimeError("posthog offline")
+
+    def schedule_capture(callback: Any) -> asyncio.Task[Any]:
+        async def run() -> Any:
+            return callback()
+
+        return asyncio.create_task(run())
+
+    with patch(
+        "custom_components.autosnooze.infrastructure.telemetry.Posthog",
+        return_value=mock_posthog,
+    ):
+        telemetry_client = TelemetryClient(hass, entry, store)
+        await telemetry_client.async_setup()
+        telemetry_client.hass.async_add_executor_job = schedule_capture
+
+        telemetry_client.track("wake_clicked", {"scope": "all"}, source="card")
+        await asyncio.gather(*telemetry_client._pending_tasks, return_exceptions=True)
+
+        telemetry_client.track("wake_clicked", {"scope": "one"}, source="card")
+        await asyncio.gather(*telemetry_client._pending_tasks, return_exceptions=True)
+
+    assert mock_posthog.capture.call_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Roll back Home Assistant state and in-memory paused/scheduled timers when a snooze save fails, so restart cannot drop a snooze that already turned a helper off or re-apply one that already woke.
- Notify and emit snooze-ended telemetry for entities that actually paused or woke in a partial batch, then still raise `pause_failed` / `wake_failed`.
- Bound telemetry unload so a hung PostHog capture cannot block config-entry teardown. Cards, sensor, and `cancel_all` are unchanged.

## Test plan
- [x] Isolated pytest: `tests/test_fail_closed_persistence.py`, `tests/test_chaos_release_040.py`, `tests/test_telemetry_client.py`, `tests/test_application_pause.py`, `tests/test_application_resume_batch_coverage.py` (85 passed)
- [ ] Confirm pause save_failed restores an originally-on `input_boolean` and leaves `data.paused` empty
- [ ] Confirm partial pause/wake notifies only the successes, then raises
- [ ] Confirm integration unload returns if PostHog capture is stuck
- [ ] Confirm the dashboard still lists automations only (no Boolean rows)


Made with [Cursor](https://cursor.com)