### PR TITLE
fix(services): use target-only entity selection for pause service

### DIFF
--- a/custom_components/autosnooze/services.yaml
+++ b/custom_components/autosnooze/services.yaml
@@ -7,16 +7,6 @@ pause:
           - automation
           - input_boolean
   fields:
-    entity_id:
-      name: Entity
-      description: Automation(s) or input Boolean(s) to snooze.
-      required: true
-      selector:
-        entity:
-          domain:
-            - automation
-            - input_boolean
-          multiple: true
     days:
       name: Days
       description: Number of days to snooze (used with duration-based scheduling).

--- a/custom_components/autosnooze/translations/en.json
+++ b/custom_components/autosnooze/translations/en.json
@@ -44,10 +44,6 @@
       "name": "Snooze",
       "description": "Snooze entities for a specified duration or until a specific time. The configured resume state is applied when the snooze ends.",
       "fields": {
-        "entity_id": {
-          "name": "Entity",
-          "description": "Automation(s) or input Boolean(s) to snooze."
-        },
         "days": {
           "name": "Days",
           "description": "Number of days to snooze."

--- a/src/tests/ha-live-sensor-contract.spec.ts
+++ b/src/tests/ha-live-sensor-contract.spec.ts
@@ -91,18 +91,22 @@ describe('getPausedSensorEntity', () => {
 });
 
 describe('card service and type contracts', () => {
-  test('PauseServiceParams field names are a subset of yaml pause fields', () => {
+  test('PauseServiceParams field names match yaml pause service contract', () => {
     const automationTs = readFileSync(automationTsPath, 'utf-8');
     const iface = automationTs.match(/export interface PauseServiceParams[\s\S]*?\{([\s\S]*?)\n\}/);
     expect(iface).not.toBeNull();
     const tsFields = [...(iface![1].matchAll(/^\s+(\w+)\??:/gm))].map((match) => match[1]);
     const servicesYaml = parseYaml(readFileSync(servicesYamlPath, 'utf-8')) as {
-      pause: { fields: Record<string, unknown> };
+      pause: { fields: Record<string, unknown>; target?: { entity?: unknown } };
     };
     const yamlFields = new Set(Object.keys(servicesYaml.pause.fields));
+    const yamlTargetFields = servicesYaml.pause.target?.entity ? new Set(['entity_id']) : new Set<string>();
 
     for (const field of tsFields) {
-      expect(yamlFields.has(field), `${field} not in services.yaml pause`).toBe(true);
+      expect(
+        yamlFields.has(field) || yamlTargetFields.has(field),
+        `${field} not in services.yaml pause fields or target`
+      ).toBe(true);
     }
     expect(tsFields).not.toContain('resume_preset');
   });

--- a/tests/fixtures/services-schema.json
+++ b/tests/fixtures/services-schema.json
@@ -4,16 +4,12 @@
   "services": {
     "pause": {
       "name": "Snooze",
+      "target": {
+        "entity": [
+          { "domain": ["automation", "input_boolean"] }
+        ]
+      },
       "fields": {
-        "entity_id": {
-          "required": true,
-          "selector": {
-            "entity": {
-              "domain": ["automation", "input_boolean"],
-              "multiple": true
-            }
-          }
-        },
         "days": {
           "required": false,
           "default": 0,

--- a/tests/test_backend_schema.spec.ts
+++ b/tests/test_backend_schema.spec.ts
@@ -295,14 +295,14 @@ describe('Services.yaml Schema Validation', () => {
       }
     });
 
-    test('pause service has correct fields', () => {
+    test('pause service uses target.entity instead of fields.entity_id', () => {
       const pauseService = servicesYaml.pause;
       expect(pauseService).toBeDefined();
-      expect(pauseService.fields).toBeDefined();
-
-      // Required field
-      expect(pauseService.fields.entity_id).toBeDefined();
-      expect(pauseService.fields.entity_id.required).toBe(true);
+      expect(pauseService.target).toBeDefined();
+      expect(pauseService.target.entity).toEqual([
+        { domain: ['automation', 'input_boolean'] },
+      ]);
+      expect(pauseService.fields.entity_id).toBeUndefined();
 
       // Optional duration fields
       expect(pauseService.fields.days).toBeDefined();
@@ -388,15 +388,18 @@ describe('Services.yaml Schema Validation', () => {
   });
 
   describe('Entity selectors', () => {
-    test('pause entity_id selector supports automation and input Boolean domains', () => {
-      const entityId = servicesYaml.pause.fields.entity_id;
-      expect(entityId.selector.entity.domain).toEqual(['automation', 'input_boolean']);
-      expect(entityId.selector.entity.multiple).toBe(true);
+    test('pause target.entity supports automation and input Boolean domains', () => {
+      expect(servicesYaml.pause.target.entity).toEqual([
+        { domain: ['automation', 'input_boolean'] },
+      ]);
+      expect(servicesSchema.services.pause.target.entity).toEqual([
+        { domain: ['automation', 'input_boolean'] },
+      ]);
+      expect(servicesSchema.services.pause.fields.entity_id).toBeUndefined();
     });
 
     test('direct entity services support automation and input Boolean domains', () => {
       const servicesWithEntityId = [
-        'pause',
         'cancel',
         'clear_notification',
         'cancel_scheduled',

--- a/tests/test_ha_card_api_contract.py
+++ b/tests/test_ha_card_api_contract.py
@@ -35,9 +35,8 @@ SENSOR_ENTITY_ID = "sensor.autosnooze_snoozed_automations"
 ENTITY_ONE = "automation.test_automation_1"
 
 PAUSE_FAMILY = ("pause", "pause_by_area", "pause_by_label")
-DIRECT_ENTITY_SERVICES = ("pause", "cancel", "clear_notification", "cancel_scheduled", "adjust")
+DIRECT_ENTITY_SERVICES = ("cancel", "clear_notification", "cancel_scheduled", "adjust")
 PAUSE_TARGET_FIELDS = {
-    "pause": "entity_id",
     "pause_by_area": "area_id",
     "pause_by_label": "label_id",
 }
@@ -154,8 +153,8 @@ def test_services_yaml_keys_match_service_names() -> None:
 def test_pause_family_yaml_includes_schema_optional_fields(service_name: str) -> None:
     services = _load_services_yaml()
     fields = set(services[service_name]["fields"])
-    target = PAUSE_TARGET_FIELDS[service_name]
-    assert target in fields
+    if service_name in PAUSE_TARGET_FIELDS:
+        assert PAUSE_TARGET_FIELDS[service_name] in fields
     missing = PAUSE_OPTIONAL_FIELDS - fields
     assert not missing, f"{service_name} missing yaml fields: {sorted(missing)}"
 
@@ -179,7 +178,11 @@ def test_direct_entity_services_support_automations_and_input_booleans(service_n
 
 def test_pause_target_supports_direct_domains_while_discovery_stays_automation_only() -> None:
     services = _load_services_yaml()
+    fixture = _load_services_fixture()
     assert services["pause"]["target"]["entity"] == [{"domain": ["automation", "input_boolean"]}]
+    assert fixture["services"]["pause"]["target"]["entity"] == [{"domain": ["automation", "input_boolean"]}]
+    assert "entity_id" not in services["pause"]["fields"]
+    assert "entity_id" not in fixture["services"]["pause"]["fields"]
     assert services["pause_by_area"]["target"]["entity"] == [{"domain": "automation"}]
     assert services["pause_by_label"]["target"]["entity"] == [{"domain": "automation"}]
 


### PR DESCRIPTION
## Summary
- Remove duplicate `fields.entity_id` from the `pause` service definition
- Keep entity selection on `target.entity` for automations and input booleans
- Update service contract tests to match Home Assistant's target-only schema

## Why
Home Assistant rejects services that define both `target.entity` and a required `fields.entity_id`. That broke the service UI when `resume_state` was set to **Previous state** for input Boolean calls:

> This action requires field entity_id, please enter a valid value for entity_id

## Test plan
- [x] `npm test -- tests/test_backend_schema.spec.ts`
- [x] `src/tests/ha-live-sensor-contract.spec.ts`
- [x] pre-commit / pre-push hooks

Made with [Cursor](https://cursor.com)